### PR TITLE
[PT-2] Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report reproducible incorrect behavior in the portfolio.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for reporting a problem. Detailed reproduction information helps us investigate it efficiently.
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: Clearly describe the problem and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable sequence that demonstrates the problem.
+      placeholder: |
+        1. Go to...
+        2. Select...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: Explain what should have happened.
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: Explain what happened instead, including any error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment information
+      description: Include the device, operating system, browser, browser version, and viewport where relevant.
+      placeholder: |
+        - Device:
+        - Operating system:
+        - Browser and version:
+        - Viewport:
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Screenshots or additional context
+      description: Add screenshots, recordings, logs, or other information that may help diagnose the issue.
+

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -56,4 +56,3 @@ body:
     attributes:
       label: Screenshots or additional context
       description: Add screenshots, recordings, logs, or other information that may help diagnose the issue.
-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/decision.yml
+++ b/.github/ISSUE_TEMPLATE/decision.yml
@@ -54,4 +54,3 @@ body:
       placeholder: Add links or write "None".
     validations:
       required: true
-

--- a/.github/ISSUE_TEMPLATE/decision.yml
+++ b/.github/ISSUE_TEMPLATE/decision.yml
@@ -1,0 +1,57 @@
+name: Architectural decision
+description: Evaluate alternatives and document a project decision.
+title: "[Decision] "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: Capture the context and evaluation needed to make a durable, traceable decision.
+  - type: textarea
+    id: context
+    attributes:
+      label: Decision context
+      description: Describe the situation that requires a decision.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: State the problem and why a decision is needed now.
+    validations:
+      required: true
+  - type: textarea
+    id: options
+    attributes:
+      label: Considered options
+      description: List the viable alternatives to compare.
+      placeholder: |
+        1. Option A
+        2. Option B
+    validations:
+      required: true
+  - type: textarea
+    id: evaluation_criteria
+    attributes:
+      label: Evaluation criteria
+      description: Define how the options will be assessed.
+      placeholder: Consider accessibility, maintainability, performance, cost, and project fit where relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_outcome
+    attributes:
+      label: Expected outcome
+      description: Describe the deliverable or decision record expected from this work.
+    validations:
+      required: true
+  - type: textarea
+    id: related_documentation
+    attributes:
+      label: Related documentation
+      description: Link relevant ADRs, issues, specifications, or external references.
+      placeholder: Add links or write "None".
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,62 @@
+name: Feature
+description: Propose user-visible functionality for the portfolio.
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for helping improve the portfolio. Provide enough detail to evaluate and implement the feature.
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature description
+      description: Describe the proposed functionality.
+      placeholder: What should be added or changed?
+    validations:
+      required: true
+  - type: textarea
+    id: user_value
+    attributes:
+      label: User value
+      description: Explain who benefits from this feature and how.
+      placeholder: This helps visitors by...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Define what is included and explicitly excluded.
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: List observable conditions that must be met for completion.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: accessibility
+    attributes:
+      label: Accessibility considerations
+      description: Describe keyboard, screen reader, contrast, motion, or other accessibility needs.
+      placeholder: Note relevant accessibility requirements or explain why none apply.
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add references, mockups, examples, or other useful information.
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -59,4 +59,3 @@ body:
     attributes:
       label: Additional context
       description: Add references, mockups, examples, or other useful information.
-

--- a/.github/ISSUE_TEMPLATE/technical-task.yml
+++ b/.github/ISSUE_TEMPLATE/technical-task.yml
@@ -58,4 +58,3 @@ body:
     attributes:
       label: Additional notes
       description: Add references, risks, alternatives, or other useful information.
-

--- a/.github/ISSUE_TEMPLATE/technical-task.yml
+++ b/.github/ISSUE_TEMPLATE/technical-task.yml
@@ -1,0 +1,61 @@
+name: Technical task
+description: Propose configuration, refactoring, testing, or infrastructure work.
+title: "[Technical Task] "
+labels:
+  - infrastructure
+body:
+  - type: markdown
+    attributes:
+      value: Describe the technical work and the constraints that affect its implementation.
+  - type: textarea
+    id: description
+    attributes:
+      label: Task description
+      description: Describe the technical work to be completed.
+      placeholder: What needs to be changed and why?
+    validations:
+      required: true
+  - type: textarea
+    id: technical_context
+    attributes:
+      label: Technical context
+      description: Explain the current state, constraints, and relevant implementation details.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Define what is included and explicitly excluded.
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: List verifiable conditions that must be met for completion.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: List blocking issues, external services, packages, or prerequisites.
+      placeholder: Link dependencies or write "None".
+    validations:
+      required: true
+  - type: textarea
+    id: additional_notes
+    attributes:
+      label: Additional notes
+      description: Add references, risks, alternatives, or other useful information.
+


### PR DESCRIPTION
## Summary

Adds reusable GitHub Issue Forms for the main types of work in the portfolio project.

Closes #3

## Changes

- Adds a feature form for user-visible functionality.
- Adds a technical task form for configuration, refactoring, testing, and infrastructure work.
- Adds an architectural decision form for evaluating and documenting project decisions.
- Adds a bug report form with reproduction and environment fields.
- Disables blank issues through the issue template configuration.
- Provides a clear title prefix, an existing repository label, and required field validations for each form.

## Repository structure

```text
.github/
└── ISSUE_TEMPLATE/
    ├── feature.yml
    ├── technical-task.yml
    ├── decision.yml
    ├── bug.yml
    └── config.yml
```

## Impact

New work can be reported consistently with the context and acceptance information needed before implementation begins. Blank issues are disabled to reduce incomplete reports.

## Verification

- Parsed and formatted every YAML file with `prettier --check`.
- Confirmed all four forms define a title prefix and an existing repository label.
- Confirmed required fields use GitHub Issue Forms validations.
- Confirmed `blank_issues_enabled` is set to `false` and no external contact links are configured.
- Confirmed `git diff --check origin/main...HEAD` passes.

## Screenshots

Not applicable. The issue chooser will use these forms after the pull request is merged into the default branch.
