### PR TITLE
[PT-3] Define repository labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,7 +2,7 @@ name: Bug report
 description: Report reproducible incorrect behavior in the portfolio.
 title: "[Bug] "
 labels:
-  - bug
+  - "type: bug"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/decision.yml
+++ b/.github/ISSUE_TEMPLATE/decision.yml
@@ -2,7 +2,7 @@ name: Architectural decision
 description: Evaluate alternatives and document a project decision.
 title: "[Decision] "
 labels:
-  - documentation
+  - "type: decision"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -2,7 +2,7 @@ name: Feature
 description: Propose user-visible functionality for the portfolio.
 title: "[Feature] "
 labels:
-  - enhancement
+  - "type: feature"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/technical-task.yml
+++ b/.github/ISSUE_TEMPLATE/technical-task.yml
@@ -2,7 +2,7 @@ name: Technical task
 description: Propose configuration, refactoring, testing, or infrastructure work.
 title: "[Technical Task] "
 labels:
-  - infrastructure
+  - "type: technical-task"
 body:
   - type: markdown
     attributes:

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,64 @@
+# Repository labels
+
+Labels classify issues and pull requests across independent dimensions. Their prefixes make the backlog predictable to filter and prevent labels with overlapping meanings.
+
+## Usage rules
+
+- Apply exactly one `type:` label to describe the kind of work.
+- Apply zero or more `area:` labels to identify the affected parts of the project.
+- Apply one `priority:` label to planned work. A priority may be omitted while an item is still being triaged.
+- Apply zero or one `status:` label only when it communicates information beyond GitHub's open or closed state.
+- Reassess labels when the scope or readiness of an item changes.
+
+## Type labels
+
+| Label                  | Color     | Description                                                           |
+| ---------------------- | --------- | --------------------------------------------------------------------- |
+| `type: feature`        | `#1D76DB` | User-visible functionality or product capability.                     |
+| `type: bug`            | `#D73A4A` | Incorrect or unexpected behavior that requires a fix.                 |
+| `type: technical-task` | `#5319E7` | Configuration, maintenance, or other technical work.                  |
+| `type: decision`       | `#8250DF` | Evaluation and documentation of an architectural or product decision. |
+| `type: documentation`  | `#0075CA` | Documentation-only work or documentation improvements.                |
+| `type: refactor`       | `#0E8A16` | Internal code improvement without changing expected behavior.         |
+| `type: testing`        | `#BFD4F2` | Test coverage, test tooling, or quality verification work.            |
+
+## Area labels
+
+| Label                  | Color     | Description                                                    |
+| ---------------------- | --------- | -------------------------------------------------------------- |
+| `area: frontend`       | `#006B75` | Frontend application structure, behavior, or implementation.   |
+| `area: design`         | `#C5DEF5` | Visual design, interaction design, or design-system work.      |
+| `area: content`        | `#FBCA04` | Portfolio copy, media, localization, or content structure.     |
+| `area: accessibility`  | `#D4C5F9` | Accessibility requirements, audits, or improvements.           |
+| `area: infrastructure` | `#545454` | Repository configuration, tooling, and project infrastructure. |
+| `area: ci-cd`          | `#0052CC` | Continuous integration and delivery workflows.                 |
+| `area: hosting`        | `#008672` | Deployment environments, domains, or hosting platforms.        |
+
+## Priority labels
+
+| Label              | Color     | Description                                                |
+| ------------------ | --------- | ---------------------------------------------------------- |
+| `priority: high`   | `#B60205` | Urgent work with high impact or a near-term deadline.      |
+| `priority: medium` | `#D93F0B` | Important planned work without immediate urgency.          |
+| `priority: low`    | `#FEF2C0` | Useful work that can be scheduled after higher priorities. |
+
+## Status labels
+
+| Label                    | Color     | Description                                                   |
+| ------------------------ | --------- | ------------------------------------------------------------- |
+| `status: blocked`        | `#000000` | Cannot progress until a dependency or impediment is resolved. |
+| `status: ready`          | `#2DA44E` | Defined and ready to be implemented.                          |
+| `status: needs-decision` | `#A371F7` | Requires a decision before implementation can continue.       |
+
+## Automatic labels
+
+GitHub Issue Forms apply the appropriate type label automatically:
+
+| Issue form             | Applied label          |
+| ---------------------- | ---------------------- |
+| Feature                | `type: feature`        |
+| Technical task         | `type: technical-task` |
+| Architectural decision | `type: decision`       |
+| Bug report             | `type: bug`            |
+
+Area, priority, and status labels are assigned during triage because they depend on the issue's context and current workflow state.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Application code and framework dependencies have intentionally not been added ye
 ```text
 .
 ├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   ├── LABELS.md
 │   └── pull_request_template.md
 ├── docs/
 │   ├── architecture/
@@ -24,6 +26,7 @@ Application code and framework dependencies have intentionally not been added ye
 - `docs/design/` stores design documentation and related resources.
 - `docs/product/` stores product requirements and planning documentation.
 - `.github/` stores repository collaboration templates and configuration.
+- [`.github/LABELS.md`](.github/LABELS.md) documents the repository label taxonomy and usage rules.
 
 ## Git workflow
 


### PR DESCRIPTION
## Summary

Defines and applies a multidimensional repository label taxonomy for classifying work by type, area, priority, and workflow status.

Closes #5

## Changes

- Creates 20 labels with English names, unique colors, and clear descriptions.
- Renames the existing feature, bug, documentation, and infrastructure labels to preserve their associations.
- Removes all obsolete GitHub default labels.
- Updates the four Issue Forms to apply the appropriate `type:` label automatically.
- Documents label cardinality, the complete catalog, colors, descriptions, and triage guidance.
- Updates the README to make the label documentation discoverable.
- Migrates the open PT-3 issue to the new taxonomy.

## Repository structure

```text
.github/
├── ISSUE_TEMPLATE/
│   ├── bug.yml
│   ├── decision.yml
│   ├── feature.yml
│   └── technical-task.yml
└── LABELS.md
```

## Impact

Issues and pull requests can now be filtered consistently across independent dimensions. New Issue Forms apply a work type automatically, while area, priority, and status remain contextual triage choices.

## Verification

- Confirmed exactly 20 repository labels exist with the expected names, colors, and descriptions.
- Confirmed the six obsolete default labels were removed.
- Confirmed issue #5 uses `type: technical-task`, `area: infrastructure`, `priority: medium`, and `status: ready`.
- Parsed and formatted all Issue Form YAML files with `prettier --check`.
- Confirmed `git diff --check origin/main...HEAD` passes.

## Screenshots

Not applicable.
