### PR TITLE
docs(PT-15): establish ADR governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Application code and framework dependencies have intentionally not been added ye
 │   └── pull_request_template.md
 ├── docs/
 │   ├── architecture/
+│   │   ├── high-level-architecture.md
 │   │   └── decisions/
+│   │       ├── README.md
+│   │       ├── template.md
+│   │       └── 0001-... through 0006-...
 │   ├── design/
 │   └── product/
 ├── .gitignore
@@ -31,6 +35,11 @@ Application code and framework dependencies have intentionally not been added ye
 - [Information architecture](docs/product/information-architecture.md) defines the portfolio sitemap, navigation hierarchy, visitor journeys, and MVP content structure.
 - [Content strategy](docs/product/content-strategy.md) defines tone, professional-content guidelines, project and case-study structures, confidentiality rules, and language strategy.
 - [Product success criteria](docs/product/product-success-criteria.md) defines the measurable communication, usability, accessibility, performance, content, maintainability, and production-readiness expectations for the portfolio.
+
+## Architecture
+
+- [High-level architecture](docs/architecture/high-level-architecture.md)
+- [Architecture decision records](docs/architecture/decisions/README.md)
 
 ## Git workflow
 

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,132 @@
+# Architecture decision records
+
+## Purpose
+
+GitHub decision issues preserve investigation and discussion. Architecture decision records (ADRs) preserve the concise accepted or rejected outcome in the repository, while the [high-level architecture](../high-level-architecture.md) combines active decisions into a living system view. The [repository README](../../../README.md) provides the entry point to both.
+
+Create ADRs for significant decisions whose context and consequences future maintainers need to understand. Ordinary implementation details and easily reversible local choices do not require an ADR. Start new records from the [reusable template](template.md).
+
+## When to create an ADR
+
+Create an ADR when a decision:
+
+- materially affects system boundaries, technology, deployment, data, security, privacy, accessibility, testing, content ownership, or maintainability;
+- introduces a constraint that is difficult or expensive to reverse;
+- resolves a meaningful architectural trade-off;
+- changes or replaces an accepted ADR; or
+- requires future maintainers to understand why one option was selected.
+
+Do not create an ADR for routine implementation details, small refactors, local component choices, ordinary dependency updates without architectural impact, formatting or documentation-only corrections, or decisions already governed directly by an accepted ADR.
+
+## Numbering and naming
+
+Use `NNNN-kebab-case-decision-title.md`.
+
+- Use a four-digit, zero-padded sequential number and allocate the next unused number.
+- Never reuse or renumber an existing ADR number.
+- Preserve numbers for rejected, deprecated, and superseded ADRs.
+- Use a concise imperative or decision-oriented kebab-case title.
+- Use `# ADR NNNN: Decision title` for the Markdown H1.
+- Do not number `template.md` or `README.md` as ADRs.
+- The next decision after the current records would use `0007`.
+
+Do not rename an existing ADR unless its filename is broken or contradicts its H1.
+
+## Supported statuses
+
+Use exactly one of these primary statuses.
+
+### Proposed
+
+The decision is documented and under review. It is not yet an active architectural constraint.
+
+### Accepted
+
+The decision has been approved and currently guides implementation.
+
+### Rejected
+
+The proposal was formally considered but not adopted. Preserve it when its reasoning provides meaningful historical value.
+
+### Deprecated
+
+The decision is no longer recommended or applicable and has no direct replacement. Explain why it ceased to apply.
+
+### Superseded
+
+A later ADR replaces the decision. The old ADR must identify and link to the replacing ADR, and the new ADR must identify the ADR it supersedes.
+
+Express required relationships alongside the status or metadata, for example:
+
+- `**Status:** Superseded by [ADR 0008](0008-example.md)`
+- `**Supersedes:** [ADR 0003](0003-example.md)`
+
+Do not introduce overlapping primary statuses such as Draft, Pending, Active, Obsolete, Amended, or Completed.
+
+## Lifecycle
+
+1. Confirm that the decision warrants an ADR.
+2. Allocate the next number and copy `template.md`.
+3. Create the ADR initially as `Proposed`.
+4. Link the ADR to its originating GitHub decision issue.
+5. Record concise context, drivers, realistic options, the decision, consequences, validation, and revisit conditions.
+6. Review the ADR through a pull request.
+7. Set it to `Accepted` or `Rejected` when the decision concludes.
+8. Update the index.
+9. Update the originating issue with the resulting ADR link.
+10. Implement the decision through separate issues or pull requests where appropriate.
+11. Revisit the ADR only when its documented triggers occur or evidence invalidates its assumptions.
+
+Do not rewrite an accepted ADR to hide a later architectural change. Minor factual corrections, link fixes, and clarifications that do not change the decision may update the existing record; a material change requires a new ADR. Superseding a record requires bidirectional links, and historical ADRs remain in the repository. The index reflects current status.
+
+Detailed investigation belongs in the GitHub issue. The ADR should remain understandable without reproducing the whole discussion.
+
+## Required ADR content
+
+An ADR is expected to contain:
+
+- a title;
+- status;
+- date;
+- decision owners;
+- a related issue;
+- related documentation where relevant;
+- context;
+- assumptions when relevant;
+- decision drivers;
+- options considered;
+- the decision;
+- consequences;
+- risks and mitigations when meaningful;
+- validation or confirmation requirements;
+- revisit conditions; and
+- references when external evidence materially supports the record.
+
+Omit a section only when it is genuinely inapplicable, not for convenience. A weighted comparison matrix is optional and should be used only when it improves an actual multi-option decision.
+
+## Editing historical ADRs
+
+- Preserve the original decision and its historical reasoning.
+- Do not silently replace an accepted choice.
+- Correct broken links, typographical errors, and demonstrably false factual statements carefully.
+- Record material changes through a new ADR.
+- Add superseding or deprecation metadata without deleting the old record.
+- Avoid rewriting historical language merely to match the latest template.
+- Apply the template to new ADRs; old ADRs need only satisfy the required semantic content.
+
+## Index
+
+| ADR | Decision | Status | Date | Originating issue | Notes or relationship |
+| --- | --- | --- | --- | --- | --- |
+| [ADR 0001](0001-use-astro-as-the-primary-frontend-framework.md) | Use Astro as the primary frontend framework | Accepted | 2026-07-31 | [PT-8 — Evaluate frontend framework](https://github.com/LuisArostegui/portfolio/issues/11) | Current |
+| [ADR 0002](0002-use-modern-css-as-the-primary-styling-strategy.md) | Use modern CSS as the primary styling strategy | Accepted | 2026-07-31 | [PT-9 — Evaluate styling strategy](https://github.com/LuisArostegui/portfolio/issues/12) | Current |
+| [ADR 0003](0003-use-a-native-first-purpose-driven-animation-strategy.md) | Use a native-first, purpose-driven animation strategy | Accepted | 2026-08-03 | [PT-10 — Evaluate animation strategy](https://github.com/LuisArostegui/portfolio/issues/13) | Current |
+| [ADR 0004](0004-use-git-versioned-astro-content-collections.md) | Use Git-versioned Astro Content Collections | Accepted | 2026-08-04 | [PT-11 — Evaluate content-management strategy](https://github.com/LuisArostegui/portfolio/issues/14) | Current |
+| [ADR 0005](0005-use-cloudflare-workers-static-assets-for-hosting.md) | Use Cloudflare Workers Static Assets for hosting | Accepted | 2026-08-04 | [PT-12 — Evaluate hosting and deployment platform](https://github.com/LuisArostegui/portfolio/issues/15) | Current |
+| [ADR 0006](0006-use-a-pragmatic-risk-based-testing-strategy.md) | Use a pragmatic risk-based testing strategy | Accepted | 2026-08-04 | [PT-13 — Evaluate testing strategy](https://github.com/LuisArostegui/portfolio/issues/16) | Current |
+
+## Related architecture documentation
+
+- [High-level architecture](../high-level-architecture.md)
+- [Product documentation](../../product/)
+- [Reusable ADR template](template.md)

--- a/docs/architecture/decisions/template.md
+++ b/docs/architecture/decisions/template.md
@@ -1,0 +1,55 @@
+# ADR NNNN: Decision title
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Decision owners:** Portfolio maintainer
+- **Related issue:** [PT-XX — Issue title](...)
+- **Related documentation:** ...
+
+<!-- Replace placeholders and remove irrelevant comments before review. Keep the final record concise; link to the GitHub issue instead of reproducing its investigation. -->
+
+## Context
+
+<!-- Describe the problem, relevant constraints, and why a decision is needed. -->
+
+## Assumptions
+
+<!-- Record assumptions that materially affect the decision. Omit this section if genuinely inapplicable. -->
+
+## Decision drivers
+
+<!-- List the criteria that distinguish the realistic options. -->
+
+## Options considered
+
+<!-- Summarise realistic options and material trade-offs. Use scoring only when it improves the decision. -->
+
+## Decision
+
+<!-- State the chosen outcome and its essential boundaries unambiguously. -->
+
+## Consequences
+
+### Positive
+
+<!-- Record expected benefits. -->
+
+### Negative
+
+<!-- Record accepted costs, limitations, and trade-offs. -->
+
+## Risks and mitigations
+
+<!-- Record meaningful risks and proportionate mitigations. Omit if genuinely inapplicable. -->
+
+## Validation requirements
+
+<!-- Explain what evidence will confirm the decision works as intended. -->
+
+## Revisit conditions
+
+<!-- Define evidence or changes that should trigger reassessment. -->
+
+## References
+
+<!-- Link external evidence that materially supports the record. Omit if genuinely inapplicable. -->


### PR DESCRIPTION
### Summary

- Added the ADR index and governance guide.
- Added the reusable ADR template.
- Audited ADR 0001 through ADR 0006.
- Added architecture navigation to the root README.
- Established repository-side traceability for issues #11 through #16.

### ADR conventions

- ADR filenames use a four-digit sequential number and a concise kebab-case decision title.
- Supported statuses are Proposed, Accepted, Rejected, Deprecated, and Superseded.
- New ADRs begin as Proposed, are reviewed through a pull request, and conclude as Accepted or Rejected.
- Deprecated decisions remain as historical records and explain why they no longer apply.
- Superseded decisions remain in the repository and link bidirectionally to their replacements.
- Accepted ADRs are not rewritten to conceal later architectural changes; material changes require a new ADR.

### Validation

- Confirmed all six existing ADRs are indexed with matching titles, dates, statuses, and originating issues.
- Confirmed all local Markdown links resolve.
- Confirmed the high-level architecture links ADR 0001 through ADR 0006.
- Confirmed the root README links the high-level architecture and ADR index.
- Confirmed `git diff --check` passes.
- Confirmed no accepted decision, evaluation score, conclusion, or technical direction was altered.

### Scope confirmation

No new architectural decision, application code, dependency, workflow, ADR tooling, infrastructure, or repository setting was introduced.

Closes #18