### PR TITLE
docs(PT-27): add Codex agent guidance

### DIFF
--- a/.agents/skills/portfolio-cloudflare/SKILL.md
+++ b/.agents/skills/portfolio-cloudflare/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: portfolio-cloudflare
+description: Configure, review, validate, or deploy the Portfolio MVP on Cloudflare Workers Static Assets or with Wrangler. Use only for Cloudflare configuration, deployment, or runtime compatibility work.
+---
+
+# Portfolio Cloudflare delivery
+
+## Purpose
+
+Keep deployment work consistent with the approved static-hosting architecture while treating Cloudflare configuration and Wrangler syntax as time-sensitive.
+
+## Procedure
+
+1. Read `AGENTS.md`, the linked issue, and ADR-0005 before editing configuration or deployment files.
+2. Retrieve current Cloudflare documentation or load the official `wrangler` skill before writing or reviewing Wrangler commands and configuration.
+3. Confirm that the proposed output is static assets plus only the approved Worker behaviour. Do not introduce server features, bindings, or platform services without a linked decision.
+4. Check runtime compatibility explicitly. Do not assume Node.js APIs are available in Worker code.
+5. Keep environment-specific values, credentials, and deployment secrets outside committed files.
+6. Run deployment or remote mutations only when the task explicitly authorises them; otherwise provide a local or dry-run validation result.
+
+## References
+
+- `docs/architecture/decisions/0005-use-cloudflare-workers-static-assets-for-hosting.md`
+- https://github.com/cloudflare/skills/tree/main/skills/wrangler

--- a/.agents/skills/portfolio-implementation/SKILL.md
+++ b/.agents/skills/portfolio-implementation/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: portfolio-implementation
+description: Implement or review Portfolio MVP work involving Astro pages or components, selective React islands, TypeScript, modern CSS, Astro Content Collections, or Zod. Use after reading AGENTS.md and the linked issue; do not use for deployment-only or validation-only tasks.
+---
+
+# Portfolio implementation
+
+## Purpose
+
+Apply the approved Portfolio architecture without duplicating its ADRs in prompts. This is a task-specific procedure, not a replacement for the governing documentation.
+
+## Procedure
+
+1. Read `AGENTS.md`, the full linked issue, and the directly relevant ADRs and design/product records.
+2. State the affected route, content, component, or interaction boundary before editing.
+3. Start with Astro-rendered semantic HTML. Introduce a React island only when the interaction needs client state or browser APIs and its boundary is contained.
+4. Use existing semantic CSS tokens and component patterns. Do not create an abstraction merely because a visual group exists.
+5. For content, define or update the collection schema before relying on the data; keep content Git-tracked and validate it with Zod.
+6. Preserve the non-JavaScript baseline and reduced-motion or accessibility requirements stated by the governing records.
+7. Select proportionate validation using `portfolio-validation` when tests or accessibility checks are relevant.
+
+## Decision gates
+
+- If an interaction is possible with semantic HTML and CSS, keep it static.
+- If a requirement is absent from the issue or governing record, do not invent it; report the gap.
+- If a proposed dependency, data source, or runtime feature is outside the accepted stack, stop and request a decision.
+
+## References
+
+- `docs/architecture/decisions/0001-use-astro-as-the-primary-frontend-framework.md`
+- `docs/architecture/decisions/0002-use-modern-css-as-the-primary-styling-strategy.md`
+- `docs/architecture/decisions/0003-use-a-native-first-purpose-driven-animation-strategy.md`
+- `docs/architecture/decisions/0004-use-git-versioned-astro-content-collections.md`
+- `docs/design/` and `docs/product/` records named by the issue

--- a/.agents/skills/portfolio-validation/SKILL.md
+++ b/.agents/skills/portfolio-validation/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: portfolio-validation
+description: Validate Portfolio MVP changes involving Vitest, React Testing Library, Playwright, axe, accessibility, browser behaviour, or release readiness. Use after the implementation boundary is known; do not use to add speculative test tooling.
+---
+
+# Portfolio validation
+
+## Purpose
+
+Apply the repository's risk-based testing strategy and produce evidence proportionate to the changed behaviour.
+
+## Procedure
+
+1. Read `AGENTS.md`, the issue acceptance criteria, and ADR-0006.
+2. Identify the observable risk and choose the smallest test layer that can demonstrate it:
+   - use Vitest for deterministic functions, schemas, and content transforms;
+   - use React Testing Library for behaviour within an interactive React island;
+   - use Playwright for critical user journeys, route integration, or browser-only behaviour;
+   - use axe where automated accessibility checks are relevant.
+3. Do not claim WCAG conformance from an automated check. Record the scope and limitations of every validation method.
+4. Prefer tests that would fail if the intended behaviour regressed. Avoid tests that merely execute implementation details.
+5. Use the package scripts and configuration already present in the checkout. Do not invent commands or add test dependencies outside the issue scope.
+6. Report commands or checks run, their outcome, and any validation intentionally not run.
+
+## Accessibility baseline
+
+Check semantic structure, keyboard access, visible focus, accessible names, and motion preferences when the changed scope makes them relevant. Escalate gaps in the approved design or interaction contract instead of silently choosing a new product behaviour.
+
+## References
+
+- `docs/architecture/decisions/0006-use-a-pragmatic-risk-based-testing-strategy.md`
+- `docs/design/component-foundations.md`
+- `docs/design/motion-interaction-guidelines.md`
+- `docs/design/design-validation-handoff.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Portfolio agent guidance
+
+These instructions apply to every task in this repository. Task-specific procedures live under `.agents/skills/`.
+
+## Source of truth
+
+1. The linked GitHub issue defines the requested scope and acceptance criteria.
+2. Accepted architecture decisions in `docs/architecture/decisions/` govern technical choices.
+3. Design and product documents govern approved content, interaction, and presentation requirements.
+4. Existing implementation and tests establish local conventions when they do not conflict with the sources above.
+
+Read the issue and directly relevant governing documents before changing files. Do not invent requirements, product content, visual details, or architectural decisions.
+
+## Architectural boundaries
+
+- Build static-first with Astro. Use React only for a contained interactive island with a real client-side responsibility.
+- Preserve progressive enhancement. A baseline task must remain usable without client JavaScript unless an approved interaction explicitly requires it.
+- Use TypeScript, modern CSS, and the established semantic token system. Do not introduce a CSS framework or design-token system without an approved decision.
+- Keep portfolio content in Git-tracked Astro Content Collections and validate collection data with Zod.
+- Target Cloudflare Workers Static Assets according to ADR-0005. Do not assume Node.js runtime APIs are available in deployed code.
+- Apply the risk-based testing strategy in ADR-0006. Choose the smallest test layer that proves the changed behaviour.
+
+## Working rules
+
+- Keep changes within the issue scope and explain any necessary scope clarification before acting.
+- Reuse an existing component only when responsibility and reuse are real; a visual group alone does not justify a component family.
+- Treat unavailable content or evidence by omitting it cleanly rather than creating placeholder UI.
+- Do not add dependencies, deployment changes, generated output, secrets, or unrelated formatting without explicit scope.
+- For documentation-only tasks, do not add production code, styles, runtime, or test scaffolding.
+- Before handoff, inspect the changed files, validate relevant links or checks, and report what was verified and what was not.
+
+## Skills
+
+- Use `portfolio-implementation` for Astro, React islands, TypeScript, CSS, or Content Collection work.
+- Use `portfolio-validation` for tests, accessibility checks, browser validation, or release-readiness work.
+- Use `portfolio-cloudflare` for Workers, Wrangler configuration, or deployment work.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Application code and framework dependencies have intentionally not been added ye
 - [High-level architecture](docs/architecture/high-level-architecture.md)
 - [Architecture decision records](docs/architecture/decisions/README.md)
 
+## Agent guidance
+
+- [Agent guidance](docs/architecture/agent-guidance.md) defines the repository-specific agent configuration, curated skills, source policy, and maintenance approach.
+- [AGENTS.md](AGENTS.md) provides the concise instructions that apply to every repository task.
+
 ## Design
 
 - [Design principles and visual direction](docs/design/design-principles.md)

--- a/docs/architecture/agent-guidance.md
+++ b/docs/architecture/agent-guidance.md
@@ -1,0 +1,75 @@
+# Agent guidance
+
+## Status
+
+Proposed by PT-27. This document defines the project-level guidance expected by coding agents working on the Portfolio MVP.
+
+## Goals
+
+- Preserve the accepted static-first architecture and avoid rediscovering the same constraints in every task.
+- Use a small set of task-specific skills instead of a broad, overlapping collection.
+- Keep repository guidance portable and reviewable alongside the source it governs.
+- Load detailed procedure only when relevant so routine tasks do not carry unnecessary context.
+
+## Configuration model
+
+| Location | Responsibility |
+| --- | --- |
+| `AGENTS.md` | Concise rules that apply to every task: source precedence, architectural boundaries, scope control, and handoff expectations. |
+| `.agents/skills/portfolio-implementation/` | On-demand procedure for Astro, React islands, TypeScript, modern CSS, Content Collections, and Zod work. |
+| `.agents/skills/portfolio-validation/` | On-demand procedure for risk-based tests, accessibility checks, browser validation, and verification evidence. |
+| `.agents/skills/portfolio-cloudflare/` | On-demand procedure for Cloudflare Workers Static Assets, Wrangler, and runtime compatibility work. |
+| Governing ADRs and design/product records | Detailed approved decisions. Skills link to them instead of copying or replacing them. |
+
+The root configuration must remain concise. A skill should have a clear trigger, a bounded procedure, and references that are loaded only when the task needs them.
+
+## Skills matrix
+
+| Technology or concern | Candidate source | Recommendation | Rationale |
+| --- | --- | --- | --- |
+| Astro | `withastro/astro` skills | Adapt | Upstream provides development and review skills, but they target the Astro monorepo. The local implementation skill retains only application-level guidance. |
+| React and TypeScript | `vercel-labs/agent-skills` React best practices | Adapt | Useful reference for isolated React behaviour; do not import Next.js or Vercel deployment assumptions into an Astro application. |
+| Modern CSS and design tokens | Existing ADR-0002 and design foundations | Create | The portfolio's semantic token and responsive rules are project-specific. |
+| Accessibility | Existing component and validation records | Create | The local validation skill preserves the approved interaction and accessibility boundaries without claiming conformance from automation alone. |
+| Astro Content Collections and Zod | ADR-0004 and Astro documentation | Create | Collection names, schemas, Git-tracked content, and editorial constraints belong to this repository. |
+| Vitest and React Testing Library | ADR-0006 | Create | The project needs a risk-based selection procedure, not a framework-wide testing playbook. |
+| Playwright and axe | Official Playwright skills and ADR-0006 | Use later | Add the official Playwright skill when browser testing is introduced. Use axe as evidence within the selected test layer, not as a declaration of WCAG conformance. |
+| GitHub workflow | Existing repository templates and configured GitHub capability | Create | The root guidance and issue/PR conventions are repository-specific; no additional generic GitHub skill is needed. |
+| Cloudflare and Wrangler | `cloudflare/skills` | Use on demand | The official Wrangler skill prefers current documentation for configuration and CLI syntax, which is valuable for time-sensitive platform work. |
+| Superpowers methodology | `obra/superpowers` | Reject as a repository dependency | Its debugging and verification procedures can be used personally when needed, but importing the full methodology would duplicate local process and increase context. |
+| Deprecated OpenAI skills catalog | `openai/skills` | Reject | The repository is deprecated in favour of current plugin examples and is not a source for new project dependencies. |
+
+## Approved external sources
+
+- https://github.com/withastro/astro/tree/main/.agents/skills
+- https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices
+- https://playwright.dev/agent-cli/skills
+- https://github.com/cloudflare/skills/tree/main/skills/wrangler
+- https://github.com/obra/superpowers
+- https://github.com/openai/skills
+
+External skills are references or on-demand tools. Their full contents are not vendored into this repository by default.
+
+## Maintenance
+
+1. Review the relevant local skill when its governing ADR, toolchain, or task workflow changes.
+2. Review an external source before first use and whenever a task depends on current CLI or platform behaviour.
+3. Keep source URLs, scope, and the recommendation in this matrix current; remove a skill that no longer has a distinct responsibility.
+4. Keep every `SKILL.md` small and move lengthy examples or changing vendor detail to referenced documentation.
+5. Review changes to `AGENTS.md` and `.agents/skills/` as production-adjacent repository configuration.
+
+## Follow-up plan
+
+1. Validate the new local guidance on the next implementation issue.
+2. Add Playwright's official skill only when an accepted task introduces browser end-to-end validation.
+3. Load Cloudflare's Wrangler skill only for configuration or deployment work.
+4. Reassess the matrix after the initial application bootstrap; do not add skills solely because they are popular.
+
+## Governing decisions
+
+- [ADR-0001: Astro](decisions/0001-use-astro-as-the-primary-frontend-framework.md)
+- [ADR-0002: Modern CSS](decisions/0002-use-modern-css-as-the-primary-styling-strategy.md)
+- [ADR-0003: Motion](decisions/0003-use-a-native-first-purpose-driven-animation-strategy.md)
+- [ADR-0004: Content Collections](decisions/0004-use-git-versioned-astro-content-collections.md)
+- [ADR-0005: Cloudflare Workers Static Assets](decisions/0005-use-cloudflare-workers-static-assets-for-hosting.md)
+- [ADR-0006: Risk-based testing](decisions/0006-use-a-pragmatic-risk-based-testing-strategy.md)


### PR DESCRIPTION
## Summary

- add concise repository-wide guidance in `AGENTS.md`
- add focused local skills for implementation, validation, and Cloudflare delivery
- document the evaluated skills matrix, external-source policy, and maintenance approach
- link the agent guidance from the README

## Scope

Documentation and agent configuration only. This PR does not add application code, dependencies, generated output, or vendored third-party skill content.

## Validation

- reviewed the changed file scope against PT-27
- checked the internal Markdown links in the new guidance
- no runtime tooling is present yet, so no build or test command applies

Refs #52