### PR TITLE
feat(PT-30): define production styling foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@astrojs/react": "6.0.2",
+    "@fontsource-variable/manrope": "5.3.0",
+    "@fontsource/ibm-plex-mono": "5.3.0",
     "astro": "7.2.2",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@astrojs/react':
         specifier: 6.0.2
         version: 6.0.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@7.2.0)(yaml@2.9.0)
+      '@fontsource-variable/manrope':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource/ibm-plex-mono':
+        specifier: 5.3.0
+        version: 5.3.0
       astro:
         specifier: 7.2.2
         version: 7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(yaml@2.9.0)
@@ -608,6 +614,12 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fontsource-variable/manrope@5.3.0':
+    resolution: {integrity: sha512-6D5dgokHsWDDMtmXHznKa0hK229NN+1a4BLPmUCLqcO1Pw5EEhWY5RFt0AcXnVRAljFFPfRtLkJePQj6LSsV6g==}
+
+  '@fontsource/ibm-plex-mono@5.3.0':
+    resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3010,6 +3022,10 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@fontsource-variable/manrope@5.3.0': {}
+
+  '@fontsource/ibm-plex-mono@5.3.0': {}
 
   '@humanfs/core@0.19.2':
     dependencies:

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,24 @@
+---
+import '../styles/global.css';
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content">
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,7 @@
 ---
-
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Portfolio</title>
-  </head>
-  <body>
-    <main>
-      <h1>Portfolio project foundation</h1>
-    </main>
-  </body>
-</html>
+<BaseLayout title="Portfolio">
+  <h1>Portfolio project foundation</h1>
+</BaseLayout>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,107 @@
+:root {
+  color-scheme: dark;
+  background-color: var(--colour-surface-page);
+  color: var(--colour-text-primary);
+  font-family: var(--type-body-font-family);
+  font-size: var(--type-body-font-size);
+  font-weight: var(--type-body-font-weight);
+  line-height: var(--type-body-line-height);
+}
+
+body {
+  min-block-size: 100vh;
+  background-color: var(--colour-surface-page);
+  color: var(--colour-text-primary);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--colour-text-primary);
+  font-family: var(--type-heading-3-font-family);
+}
+
+h1 {
+  font-size: var(--type-heading-1-font-size);
+  font-weight: var(--type-heading-1-font-weight);
+  line-height: var(--type-heading-1-line-height);
+}
+
+h2 {
+  font-size: var(--type-heading-2-font-size);
+  font-weight: var(--type-heading-2-font-weight);
+  line-height: var(--type-heading-2-line-height);
+}
+
+h3 {
+  font-size: var(--type-heading-3-font-size);
+  font-weight: var(--type-heading-3-font-weight);
+  line-height: var(--type-heading-3-line-height);
+}
+
+small {
+  font-family: var(--type-body-small-font-family);
+  font-size: var(--type-body-small-font-size);
+  font-weight: var(--type-body-small-font-weight);
+  line-height: var(--type-body-small-line-height);
+}
+
+label {
+  font-family: var(--type-label-font-family);
+  font-size: var(--type-label-font-size);
+  font-weight: var(--type-label-font-weight);
+  line-height: var(--type-label-line-height);
+}
+
+code,
+kbd,
+samp,
+pre {
+  font-family: var(--type-code-font-family);
+  font-size: var(--type-code-font-size);
+  font-weight: var(--type-code-font-weight);
+  line-height: var(--type-code-line-height);
+}
+
+a {
+  color: var(--colour-text-accent);
+  text-decoration-line: underline;
+  text-decoration-thickness: from-font;
+}
+
+a:hover {
+  color: var(--colour-accent-hover);
+}
+
+a:active {
+  color: var(--colour-accent-active);
+}
+
+:focus-visible {
+  outline: var(--space-1) solid var(--colour-focus-ring);
+  outline-offset: var(--space-1);
+}
+
+::selection {
+  background-color: var(--colour-accent-default);
+  color: var(--colour-text-on-accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto;
+    animation: none;
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  :focus-visible {
+    outline-color: Highlight;
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,6 @@
+@layer reset, tokens, base, utilities;
+
+@import './reset.css' layer(reset);
+@import './tokens.css' layer(tokens);
+@import './base.css' layer(base);
+@import './utilities.css' layer(utilities);

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,0 +1,40 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  text-size-adjust: 100%;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
+img,
+picture,
+svg,
+video,
+canvas {
+  display: block;
+  max-inline-size: 100%;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,116 @@
+@font-face {
+  font-family: 'Manrope';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400 800;
+  src: url('@fontsource-variable/manrope/files/manrope-latin-wght-normal.woff2')
+    format('woff2-variations');
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-400-normal.woff2')
+    format('woff2');
+}
+
+:root {
+  --colour-neutral-0: #ffffff;
+  --colour-neutral-100: #f5f7fa;
+  --colour-neutral-300: #d4d9e1;
+  --colour-neutral-500: #8a93a3;
+  --colour-neutral-700: #444c5a;
+  --colour-neutral-800: #2b313b;
+  --colour-neutral-850: #22272f;
+  --colour-neutral-900: #171b21;
+  --colour-neutral-950: #0d0f12;
+
+  --colour-accent-400: #a9b4ff;
+  --colour-accent-500: #8b9cff;
+  --colour-accent-600: #6f7fea;
+
+  --colour-surface-page: var(--colour-neutral-950);
+  --colour-surface-default: var(--colour-neutral-900);
+  --colour-surface-subtle: var(--colour-neutral-850);
+  --colour-surface-elevated: var(--colour-neutral-800);
+  --colour-text-primary: var(--colour-neutral-100);
+  --colour-text-secondary: var(--colour-neutral-300);
+  --colour-text-muted: var(--colour-neutral-500);
+  --colour-text-accent: var(--colour-accent-400);
+  --colour-text-on-accent: var(--colour-neutral-950);
+  --colour-border-subtle: var(--colour-neutral-800);
+  --colour-border-strong: var(--colour-neutral-700);
+  --colour-border-accent: var(--colour-accent-500);
+  --colour-accent-default: var(--colour-accent-500);
+  --colour-accent-hover: var(--colour-accent-400);
+  --colour-accent-active: var(--colour-accent-600);
+  --colour-focus-ring: var(--colour-accent-400);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 96px;
+
+  --radius-0: 0px;
+  --radius-1: 8px;
+  --radius-2: 16px;
+  --radius-pill: 999px;
+
+  --container-readable: 720px;
+  --container-standard: 1120px;
+  --container-wide: 1360px;
+  --layout-content-readable: var(--container-readable);
+  --layout-content-standard: var(--container-standard);
+  --layout-content-wide: var(--container-wide);
+  --layout-gutter-mobile: 20px;
+  --layout-gutter-tablet: 32px;
+  --layout-gutter-desktop: 48px;
+
+  --type-display-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-display-font-size: 64px;
+  --type-display-line-height: 68px;
+  --type-display-font-weight: 800;
+  --type-heading-1-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-heading-1-font-size: 48px;
+  --type-heading-1-line-height: 56px;
+  --type-heading-1-font-weight: 700;
+  --type-heading-2-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-heading-2-font-size: 36px;
+  --type-heading-2-line-height: 44px;
+  --type-heading-2-font-weight: 700;
+  --type-heading-3-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-heading-3-font-size: 28px;
+  --type-heading-3-line-height: 36px;
+  --type-heading-3-font-weight: 600;
+  --type-body-large-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-body-large-font-size: 20px;
+  --type-body-large-line-height: 30px;
+  --type-body-large-font-weight: 400;
+  --type-body-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-body-font-size: 16px;
+  --type-body-line-height: 26px;
+  --type-body-font-weight: 400;
+  --type-body-small-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-body-small-font-size: 14px;
+  --type-body-small-line-height: 22px;
+  --type-body-small-font-weight: 400;
+  --type-label-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-label-font-size: 14px;
+  --type-label-line-height: 20px;
+  --type-label-font-weight: 600;
+  --type-metadata-font-family: 'Manrope', 'Inter', system-ui, sans-serif;
+  --type-metadata-font-size: 12px;
+  --type-metadata-line-height: 18px;
+  --type-metadata-font-weight: 500;
+  --type-code-font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  --type-code-font-size: 14px;
+  --type-code-line-height: 22px;
+  --type-code-font-weight: 400;
+}

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1,0 +1,26 @@
+.visually-hidden {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: fixed;
+  inset-block-start: var(--space-4);
+  inset-inline-start: var(--space-4);
+  z-index: 1;
+  padding: var(--space-3) var(--space-4);
+  background-color: var(--colour-accent-default);
+  color: var(--colour-text-on-accent);
+  transform: translateY(calc(-100% - var(--space-4)));
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary

Establish the production styling foundation from the approved architecture and design documentation.

This introduces the global CSS entry point, approved design tokens, base typography and accessibility styles, proportional self-hosted font loading, and a minimal Astro layout without adding page-specific portfolio design.

## Related issue

Closes #55

## Changes

- Add `src/styles/global.css` as the single global stylesheet entry point.
- Define the explicit `reset`, `tokens`, `base`, and `utilities` cascade layers.
- Add the approved primitive and semantic colour, spacing, radius, container, gutter, and typography tokens.
- Add global typography, surfaces, links, text selection, visible focus, forced-colors, and reduced-motion foundations.
- Add the `.visually-hidden` and `.skip-link` accessibility utilities.
- Add a minimal `BaseLayout.astro` that imports the global foundation and provides a skip link and main-content target.
- Refactor the existing Home placeholder route to use `BaseLayout` without adding product content or page-specific presentation.
- Add proportional, self-hosted Manrope and IBM Plex Mono loading through Fontsource with `font-display: swap`.
- Update the pnpm lockfile for the Fontsource dependencies.

## Repository structure

```text
src/
├── layouts/
│   └── BaseLayout.astro
├── pages/
│   └── index.astro
└── styles/
    ├── global.css
    ├── reset.css
    ├── tokens.css
    ├── base.css
    └── utilities.css