### PR TITLE
test(PT-33): establish end-to-end and accessibility test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ coverage/
 .nyc_output/
 *.lcov
 
+# Playwright results and reports
+playwright-report/
+test-results/
+
 # Build and tooling caches
 *.tsbuildinfo
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ pnpm install
 pnpm dev
 ```
 
+Before running browser tests on a new machine, install the only browser used by the focused suite:
+
+```sh
+pnpm exec playwright install chromium
+```
+
 The other project commands are:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ pnpm format:check  # Check source and Markdown formatting
 pnpm format:write  # Format source and Markdown files
 pnpm test          # Run the Vitest unit and component suite once
 pnpm test:watch    # Run Vitest in watch mode during development
+pnpm test:e2e      # Build the site and run focused Playwright browser tests
 pnpm check         # Run Astro and TypeScript static checks
 pnpm build         # Generate the static production output in dist/
 pnpm preview       # Preview the production build locally
@@ -77,6 +78,7 @@ Commit only `pnpm-lock.yaml`; do not create or commit lockfiles from other packa
 ├── package.json
 ├── pnpm-lock.yaml
 ├── pnpm-workspace.yaml
+├── playwright.config.mjs
 ├── prettier.config.mjs
 ├── vitest.config.ts
 └── README.md

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,7 +28,7 @@ React is configured in the application, but there is currently no interactive Re
 
 ## Browser and manual boundaries
 
-Playwright runs with `pnpm test:e2e` against a freshly generated Astro production build. The command builds Astro first; Playwright then supervises Vite's static preview of `dist/` directly because the installed Astro CLI starts its own preview process in the background. The suite never uses the development server. The initial projects are Chromium and an emulated Pixel 7, which gives the focused suite one desktop and one representative mobile execution without an exhaustive browser matrix. The Playwright HTML report and test result directories are generated locally and ignored by Git.
+Playwright runs with `pnpm test:e2e` against a freshly generated Astro production build. The command builds Astro first; Playwright then supervises Vite's static preview of `dist/` directly because the installed Astro CLI starts its own preview process in the background. The suite never uses the development server. The initial projects are Chromium and an emulated Pixel 7, which gives the focused suite one desktop and one representative mobile execution without an exhaustive browser matrix. A new machine must run `pnpm exec playwright install chromium` before browser tests; generated test results are ignored by Git.
 
 The current smoke test proves that the available Home route loads, exposes its keyboard-reachable skip link and has no axe-detectable violations in either configured project. Its axe result is an automated signal only; it does not establish WCAG 2.2 AA conformance.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,17 @@ React is configured in the application, but there is currently no interactive Re
 
 ## Browser and manual boundaries
 
-Keep complete routes, generated pages, navigation between routes, browser-only APIs, JavaScript failure behaviour, responsive layout, production-output integration, and critical journeys for a separately approved Playwright/E2E foundation. Do not simulate those outcomes in Vitest merely to increase coverage.
+Playwright runs with `pnpm test:e2e` against a freshly generated Astro production build. The command builds Astro first; Playwright then supervises Vite's static preview of `dist/` directly because the installed Astro CLI starts its own preview process in the background. The suite never uses the development server. The initial projects are Chromium and an emulated Pixel 7, which gives the focused suite one desktop and one representative mobile execution without an exhaustive browser matrix. The Playwright HTML report and test result directories are generated locally and ignored by Git.
 
-Manual validation remains responsible for visual quality, content accuracy and confidentiality, real keyboard and screen-reader usability, focus visibility and order, zoom and reflow, touch behaviour, animation comfort, and WCAG 2.2 AA assessment. Automated tests provide repeatable evidence for defined behaviours; they do not replace accountable human review.
+The current smoke test proves that the available Home route loads, exposes its keyboard-reachable skip link and has no axe-detectable violations in either configured project. Its axe result is an automated signal only; it does not establish WCAG 2.2 AA conformance.
+
+As implementation adds the approved routes and shared navigation, extend this suite with real user journeys rather than fixtures or artificial controls:
+
+- Home reaches Projects and Experience, and project listings reach a published detail route;
+- the compact navigation can be opened and closed with keyboard input, exposes its accessible name and expanded state, preserves useful focus order, and works at the representative mobile viewport;
+- the same navigation keeps its semantic final state and usable focus when `prefers-reduced-motion: reduce` is active; and
+- representative completed routes and activated interactive states receive targeted axe scans where the browser journey makes that coverage meaningful.
+
+Do not simulate those outcomes in Vitest merely to increase coverage. Add tests only with the route or interaction that supplies the observable behaviour; until then, the listed journeys remain intentionally pending rather than passing against placeholders.
+
+Manual validation remains responsible for visual quality, content accuracy and confidentiality, real keyboard and screen-reader usability, focus visibility and order, zoom and reflow, touch behaviour, animation comfort, and WCAG 2.2 AA assessment. In particular, when responsive navigation is implemented, review its visible focus, logical keyboard order, assistive-technology announcement, touch operation, no-JavaScript fallback where provided, and reduced-motion behaviour. Automated tests provide repeatable evidence for defined behaviours; they do not replace accountable human review.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "preview": "astro preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "pnpm build && playwright test",
     "check": "astro check",
     "lint": "eslint .",
     "format:check": "prettier --check .",
@@ -28,7 +29,9 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
+    "@axe-core/playwright": "^4.13.0",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.4",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
   forbidOnly: !!env.CI,
-  reporter: env.CI ? 'html' : 'list',
+  reporter: 'list',
   use: {
     baseURL: 'http://127.0.0.1:4321',
     trace: 'on-first-retry',

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { env } from 'node:process';
+
+const require = createRequire(import.meta.url);
+const astroPackagePath = require.resolve('astro/package.json');
+const vitePackagePath = require.resolve('vite/package.json', {
+  paths: [path.dirname(astroPackagePath)],
+});
+const viteCliPath = path.join(path.dirname(vitePackagePath), 'bin', 'vite.js');
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!env.CI,
+  reporter: env.CI ? 'html' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4321',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `node "${viteCliPath}" preview --outDir dist --host 127.0.0.1 --port 4321 --strictPort`,
+    gracefulShutdown: {
+      signal: 'SIGTERM',
+      timeout: 500,
+    },
+    url: 'http://127.0.0.1:4321',
+    reuseExistingServer: !env.CI,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile-chromium',
+      use: { ...devices['Pixel 7'] },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,15 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.10
         version: 0.9.10(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@6.0.3)
+      '@axe-core/playwright':
+        specifier: ^4.13.0
+        version: 4.13.0(playwright-core@1.62.1)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.1(supports-color@7.2.0))
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@testing-library/jest-dom':
         specifier: ^7.0.1
         version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.10(jsdom@30.0.1)(vite@8.2.1(esbuild@0.28.2)(yaml@2.9.0)))
@@ -268,6 +274,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.4':
     resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
+
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -911,6 +922,11 @@ packages:
   '@oxc-project/types@0.144.0':
     resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@rolldown/binding-android-arm64@1.2.4':
     resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1355,6 +1371,10 @@ packages:
       '@astrojs/markdown-remark':
         optional: true
 
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1740,6 +1760,11 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2166,6 +2191,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-selector-parser@7.1.5:
     resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
@@ -3092,6 +3127,11 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
+  '@axe-core/playwright@4.13.0(playwright-core@1.62.1)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.62.1
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3602,6 +3642,10 @@ snapshots:
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/types@0.144.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.2.4':
     optional: true
@@ -4163,6 +4207,8 @@ snapshots:
       - uploadthing
       - yaml
 
+  axe-core@4.13.0: {}
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -4550,6 +4596,9 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4952,6 +5001,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@7.1.5:
     dependencies:

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,21 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test('home provides a keyboard skip link and has no automatically detectable accessibility violations', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  await expect(
+    page.getByRole('heading', { name: 'Portfolio project foundation' }),
+  ).toBeVisible();
+
+  await page.keyboard.press('Tab');
+  const skipLink = page.getByRole('link', { name: 'Skip to main content' });
+  await expect(skipLink).toBeFocused();
+  await expect(skipLink).toHaveAttribute('href', '#main-content');
+
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+  expect(accessibilityScanResults.violations).toEqual([]);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ import { getViteConfig } from 'astro/config';
 export default getViteConfig({
   test: {
     environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}'],
     restoreMocks: true,
     setupFiles: ['./tests/setup.ts'],
   },


### PR DESCRIPTION
## Summary

- add a focused Playwright setup for Chromium desktop and a representative mobile viewport
- run browser tests against an Astro production build, served from `dist/`
- add an initial Home smoke journey covering keyboard access to the skip link and an axe scan
- document browser-test responsibilities, manual validation boundaries, and the deferred navigation/reduced-motion journeys
- keep Vitest scoped to source-adjacent unit and component tests

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e`
- `pnpm test:e2e -- --repeat-each=5`
- `git diff --check`

## Scope notes

- No production navigation, routes, mocks, page objects, visual snapshots, CI, or broad browser matrix were added.
- The current application has no responsive navigation or implemented Projects/Experience routes. Their real Playwright journeys, keyboard/focus checks, reduced-motion coverage, and targeted axe scans are documented as pending work rather than tested against fixtures.
- Axe reports no automatically detectable violations in the current Home smoke journey; this is not a WCAG conformance claim.
- `pnpm format:check` remains blocked by pre-existing formatting issues in `src/lib/content/content-queries.test.ts` and `tests/setup.ts`, which are outside this issue’s scope.

Refs #58