### PR TITLE
feat(PT-37): add shared application shell and navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Read the issue and directly relevant governing documents before changing files. 
 - Treat unavailable content or evidence by omitting it cleanly rather than creating placeholder UI.
 - Do not add dependencies, deployment changes, generated output, secrets, or unrelated formatting without explicit scope.
 - For documentation-only tasks, do not add production code, styles, runtime, or test scaffolding.
+- Keep component styles inside `.astro` files by default. Extract CSS only when it is genuinely shared or large enough that separation materially improves readability. Do not create one CSS file per component as a default pattern.
 - Before handoff, inspect the changed files, validate relevant links or checks, and report what was verified and what was not.
 
 ## Skills
@@ -34,3 +35,14 @@ Read the issue and directly relevant governing documents before changing files. 
 - Use `portfolio-implementation` for Astro, React islands, TypeScript, CSS, or Content Collection work.
 - Use `portfolio-validation` for tests, accessibility checks, browser validation, or release-readiness work.
 - Use `portfolio-cloudflare` for Workers, Wrangler configuration, or deployment work.
+
+## Recommended model routing
+
+Use these recommendations as guidance, not as mandatory routing rules.
+
+- GPT-5.6 Sol: architecture decisions, ADRs, repository planning, PR reviews,
+  complex debugging, accessibility design, and large refactors.
+- GPT-5.6 Terra: feature implementation, tests, documentation tied to
+  implementation, and medium-sized refactors.
+- GPT-5.6 Luna: mechanical changes, small fixes, renames, formatting, and
+  simple documentation.

--- a/docs/architecture/high-level-architecture.md
+++ b/docs/architecture/high-level-architecture.md
@@ -107,6 +107,18 @@ Content and ordinary presentation state are resolved primarily at build time. In
 
 The examples are decision guidance, not approval or roadmap commitments for any interactive feature. A proposed island still requires a specific need, an appropriate fallback, serialisable inputs, accessible behaviour, and review of its browser cost.
 
+### Component styling conventions
+
+Component styles live in the owning `.astro` file by default. This keeps the
+markup, states, responsive rules, and visual responsibility together while a
+component is small and locally owned. Global styles remain limited to resets,
+semantic tokens, base element styling, and shared accessibility utilities.
+
+Extract CSS only when it is genuinely shared by multiple components or when a
+component stylesheet is large enough that separation materially improves
+readability. A one-CSS-file-per-component structure is not a default pattern.
+React islands continue to use CSS Modules when they are justified.
+
 ## 8. High-level application diagram
 
 ```mermaid

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -26,7 +26,7 @@ export default defineConfig({
       timeout: 500,
     },
     url: 'http://127.0.0.1:4321',
-    reuseExistingServer: !env.CI,
+    reuseExistingServer: false,
   },
   projects: [
     {

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,94 @@
+---
+import {
+  getLinkAttributes,
+  isCurrentPage,
+  primaryNavigation,
+} from '../lib/siteNavigation';
+
+const pathname = Astro.url.pathname;
+---
+
+<footer class="site-footer">
+  <div class="site-footer__content">
+    <p class="site-footer__name">Portfolio</p>
+    <nav aria-label="Footer navigation">
+      <ul class="site-footer__navigation-list">
+        {
+          primaryNavigation.map((item) => (
+            <li>
+              <a
+                aria-current={
+                  isCurrentPage(item, pathname) ? 'page' : undefined
+                }
+                href={item.href}
+                {...getLinkAttributes(item)}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    border-block-start: 1px solid var(--colour-border-subtle);
+  }
+
+  .site-footer__content {
+    display: flex;
+    inline-size: min(
+      100% - (2 * var(--layout-gutter-mobile)),
+      var(--layout-content-standard)
+    );
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding-block: var(--space-5);
+    margin-inline: auto;
+  }
+
+  .site-footer__name {
+    color: var(--colour-text-secondary);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+  }
+
+  .site-footer__navigation-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .site-footer a {
+    color: var(--colour-text-secondary);
+  }
+
+  .site-footer a[aria-current='page'] {
+    color: var(--colour-text-primary);
+    font-weight: var(--type-label-font-weight);
+  }
+
+  @media (min-width: 48rem) {
+    .site-footer__content {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-tablet)),
+        var(--layout-content-standard)
+      );
+    }
+  }
+
+  @media (max-width: 35rem) {
+    .site-footer__content {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -81,17 +81,21 @@ const pathname = Astro.url.pathname;
     const toggle =
       header.querySelector<HTMLButtonElement>('[data-menu-toggle]');
     const navigation = header.querySelector<HTMLElement>('[data-navigation]');
-    const menuIcon = header.querySelector<HTMLElement>('[data-menu-icon]');
-    const closeIcon = header.querySelector<HTMLElement>('[data-close-icon]');
+    const menuIcon = header.querySelector<SVGElement>('[data-menu-icon]');
+    const closeIcon = header.querySelector<SVGElement>('[data-close-icon]');
     const label = header.querySelector<HTMLElement>('[data-menu-label]');
     const compactNavigation = window.matchMedia('(max-width: 47.99rem)');
 
     if (toggle && navigation && menuIcon && closeIcon && label) {
+      const setIconVisibility = (icon: SVGElement, visible: boolean) => {
+        icon.toggleAttribute('hidden', !visible);
+      };
+
       const setExpanded = (expanded: boolean) => {
         toggle.setAttribute('aria-expanded', String(expanded));
         navigation.hidden = !expanded;
-        menuIcon.hidden = expanded;
-        closeIcon.hidden = !expanded;
+        setIconVisibility(menuIcon, !expanded);
+        setIconVisibility(closeIcon, expanded);
         label.textContent = expanded
           ? 'Close navigation menu'
           : 'Open navigation menu';
@@ -176,12 +180,11 @@ const pathname = Astro.url.pathname;
     block-size: 20px;
   }
 
-  .site-header__menu-icon[data-close-icon] {
+  .site-header__menu-toggle[aria-expanded='true']
+    .site-header__menu-icon[data-menu-icon],
+  .site-header__menu-toggle[aria-expanded='false']
+    .site-header__menu-icon[data-close-icon] {
     display: none;
-  }
-
-  .site-header__menu-icon[data-close-icon]:not([hidden]) {
-    display: block;
   }
 
   .site-header__navigation-list {

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -1,0 +1,263 @@
+---
+import {
+  getLinkAttributes,
+  isCurrentPage,
+  primaryNavigation,
+} from '../lib/siteNavigation';
+
+const pathname = Astro.url.pathname;
+---
+
+<header class="site-header" data-site-header>
+  <div class="site-header__content">
+    <a class="site-header__brand" href="/">Portfolio</a>
+    <button
+      class="site-header__menu-toggle"
+      type="button"
+      aria-controls="primary-navigation"
+      aria-expanded="false"
+      hidden
+      data-menu-toggle
+    >
+      <svg
+        aria-hidden="true"
+        class="site-header__menu-icon"
+        data-menu-icon
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M4 7h16M4 12h16M4 17h16"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="2"></path>
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="site-header__menu-icon"
+        data-close-icon
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m6 6 12 12M18 6 6 18"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="2"></path>
+      </svg>
+      <span data-menu-label>Open navigation menu</span>
+    </button>
+    <nav
+      aria-label="Primary navigation"
+      class="site-header__navigation"
+      id="primary-navigation"
+      data-navigation
+    >
+      <ul class="site-header__navigation-list">
+        {
+          primaryNavigation.map((item) => (
+            <li>
+              <a
+                aria-current={
+                  isCurrentPage(item, pathname) ? 'page' : undefined
+                }
+                href={item.href}
+                {...getLinkAttributes(item)}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<script>
+  const header = document.querySelector<HTMLElement>('[data-site-header]');
+
+  if (header) {
+    const toggle =
+      header.querySelector<HTMLButtonElement>('[data-menu-toggle]');
+    const navigation = header.querySelector<HTMLElement>('[data-navigation]');
+    const menuIcon = header.querySelector<HTMLElement>('[data-menu-icon]');
+    const closeIcon = header.querySelector<HTMLElement>('[data-close-icon]');
+    const label = header.querySelector<HTMLElement>('[data-menu-label]');
+    const compactNavigation = window.matchMedia('(max-width: 47.99rem)');
+
+    if (toggle && navigation && menuIcon && closeIcon && label) {
+      const setExpanded = (expanded: boolean) => {
+        toggle.setAttribute('aria-expanded', String(expanded));
+        navigation.hidden = !expanded;
+        menuIcon.hidden = expanded;
+        closeIcon.hidden = !expanded;
+        label.textContent = expanded
+          ? 'Close navigation menu'
+          : 'Open navigation menu';
+      };
+
+      const updateLayout = () => {
+        const isCompact = compactNavigation.matches;
+
+        header.toggleAttribute('data-navigation-enhanced', isCompact);
+        toggle.hidden = !isCompact;
+
+        if (isCompact) {
+          setExpanded(false);
+        } else {
+          navigation.hidden = false;
+        }
+      };
+
+      toggle.addEventListener('click', () => {
+        setExpanded(toggle.getAttribute('aria-expanded') !== 'true');
+      });
+
+      header.addEventListener('keydown', (event) => {
+        if (
+          event.key === 'Escape' &&
+          toggle.getAttribute('aria-expanded') === 'true'
+        ) {
+          setExpanded(false);
+          toggle.focus();
+        }
+      });
+
+      compactNavigation.addEventListener('change', updateLayout);
+      updateLayout();
+    }
+  }
+</script>
+
+<style>
+  .site-header {
+    border-block-end: 1px solid var(--colour-border-subtle);
+  }
+
+  .site-header__content {
+    display: flex;
+    inline-size: min(
+      100% - (2 * var(--layout-gutter-mobile)),
+      var(--layout-content-standard)
+    );
+    min-block-size: 72px;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    margin-inline: auto;
+  }
+
+  .site-header__brand {
+    color: var(--colour-text-primary);
+    font-family: var(--type-heading-3-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-heading-3-font-weight);
+    text-decoration: none;
+  }
+
+  .site-header__menu-toggle {
+    display: none;
+    min-block-size: 44px;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--colour-border-strong);
+    border-radius: var(--radius-1);
+    background-color: transparent;
+    color: var(--colour-text-primary);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+  }
+
+  .site-header__menu-icon {
+    inline-size: 20px;
+    block-size: 20px;
+  }
+
+  .site-header__menu-icon[data-close-icon] {
+    display: none;
+  }
+
+  .site-header__menu-icon[data-close-icon]:not([hidden]) {
+    display: block;
+  }
+
+  .site-header__navigation-list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .site-header__navigation a {
+    display: inline-flex;
+    min-block-size: 44px;
+    align-items: center;
+    padding-inline: var(--space-3);
+    border-block-end: 2px solid transparent;
+    color: var(--colour-text-secondary);
+    font-family: var(--type-label-font-family);
+    text-decoration: none;
+  }
+
+  .site-header__navigation a:hover {
+    color: var(--colour-text-primary);
+  }
+
+  .site-header__navigation a[aria-current='page'] {
+    border-block-end-color: var(--colour-border-accent);
+    color: var(--colour-text-primary);
+    font-weight: var(--type-label-font-weight);
+  }
+
+  @media (min-width: 48rem) {
+    .site-header__content {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-tablet)),
+        var(--layout-content-standard)
+      );
+    }
+  }
+
+  @media (max-width: 47.99rem) {
+    .site-header__content {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      padding-block: var(--space-2);
+    }
+
+    .site-header__brand {
+      grid-column: 1;
+    }
+
+    .site-header__menu-toggle {
+      display: inline-flex;
+      grid-column: 2;
+      justify-self: end;
+    }
+
+    .site-header__navigation {
+      grid-column: 1 / -1;
+    }
+
+    .site-header__navigation-list {
+      display: grid;
+      gap: 0;
+      padding-block-start: var(--space-2);
+      border-block-start: 1px solid var(--colour-border-subtle);
+    }
+
+    .site-header__navigation a {
+      padding-inline: 0;
+    }
+
+    .site-header[data-navigation-enhanced] .site-header__navigation[hidden] {
+      display: none;
+    }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,7 @@
 ---
 import '../styles/global.css';
+import SiteFooter from '../components/SiteFooter.astro';
+import SiteHeader from '../components/SiteHeader.astro';
 
 interface Props {
   title: string;
@@ -17,8 +19,30 @@ const { title } = Astro.props;
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to main content</a>
-    <main id="main-content">
+    <SiteHeader />
+    <main id="main-content" tabindex="-1">
       <slot />
     </main>
+    <SiteFooter />
   </body>
 </html>
+
+<style>
+  main {
+    inline-size: min(
+      100% - (2 * var(--layout-gutter-mobile)),
+      var(--layout-content-standard)
+    );
+    padding-block: var(--space-7);
+    margin-inline: auto;
+  }
+
+  @media (min-width: 48rem) {
+    main {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-tablet)),
+        var(--layout-content-standard)
+      );
+    }
+  }
+</style>

--- a/src/lib/siteNavigation.test.ts
+++ b/src/lib/siteNavigation.test.ts
@@ -14,6 +14,8 @@ describe('site navigation', () => {
     };
 
     expect(isCurrentPage(projects, '/projects')).toBe(true);
+    expect(isCurrentPage(projects, '/projects/')).toBe(true);
+    expect(isCurrentPage(projects, '/projects///')).toBe(true);
     expect(isCurrentPage(projects, '/projects/example')).toBe(false);
   });
 

--- a/src/lib/siteNavigation.test.ts
+++ b/src/lib/siteNavigation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getLinkAttributes,
+  isCurrentPage,
+  type NavigationItem,
+} from './siteNavigation';
+
+describe('site navigation', () => {
+  it('marks only an exact internal route as the current page', () => {
+    const projects: NavigationItem = {
+      label: 'Projects',
+      href: '/projects',
+      kind: 'internal',
+    };
+
+    expect(isCurrentPage(projects, '/projects')).toBe(true);
+    expect(isCurrentPage(projects, '/projects/example')).toBe(false);
+  });
+
+  it('derives safe external-link attributes from the item kind', () => {
+    const item = {
+      label: 'GitHub',
+      href: 'https://github.com/example',
+      kind: 'external',
+    } as const satisfies NavigationItem;
+
+    expect(getLinkAttributes(item)).toEqual({
+      target: '_blank',
+      rel: 'noreferrer',
+    });
+  });
+
+  it('derives the native download attribute from the item kind', () => {
+    const item = {
+      label: 'Download CV',
+      href: '/cv.pdf',
+      kind: 'download',
+    } as const satisfies NavigationItem;
+
+    expect(getLinkAttributes(item)).toEqual({ download: true });
+  });
+});

--- a/src/lib/siteNavigation.test.ts
+++ b/src/lib/siteNavigation.test.ts
@@ -9,14 +9,14 @@ describe('site navigation', () => {
   it('marks only an exact internal route as the current page', () => {
     const projects: NavigationItem = {
       label: 'Projects',
-      href: '/projects',
+      href: '/projects/',
       kind: 'internal',
     };
 
     expect(isCurrentPage(projects, '/projects')).toBe(true);
     expect(isCurrentPage(projects, '/projects/')).toBe(true);
     expect(isCurrentPage(projects, '/projects///')).toBe(true);
-    expect(isCurrentPage(projects, '/projects/example')).toBe(false);
+    expect(isCurrentPage(projects, '/projects/example/')).toBe(false);
   });
 
   it('derives safe external-link attributes from the item kind', () => {

--- a/src/lib/siteNavigation.ts
+++ b/src/lib/siteNavigation.ts
@@ -26,8 +26,8 @@ function normalizePathname(value: string) {
 
 export const primaryNavigation = [
   { label: 'Home', href: '/', kind: 'internal' },
-  { label: 'Projects', href: '/projects', kind: 'internal' },
-  { label: 'Experience', href: '/experience', kind: 'internal' },
+  { label: 'Projects', href: '/projects/', kind: 'internal' },
+  { label: 'Experience', href: '/experience/', kind: 'internal' },
 ] satisfies readonly NavigationItem[];
 
 export function getLinkAttributes(item: NavigationItem): LinkAttributes {

--- a/src/lib/siteNavigation.ts
+++ b/src/lib/siteNavigation.ts
@@ -1,0 +1,37 @@
+import type { HTMLAttributes } from 'astro/types';
+
+type NavigationItemKind = 'internal' | 'external' | 'download';
+
+export type NavigationItem = {
+  [Kind in NavigationItemKind]: {
+    label: string;
+    href: string;
+    kind: Kind;
+  };
+}[NavigationItemKind];
+
+type LinkAttributes = Partial<
+  Pick<HTMLAttributes<'a'>, 'target' | 'rel' | 'download'>
+>;
+
+export const primaryNavigation = [
+  { label: 'Home', href: '/', kind: 'internal' },
+  { label: 'Projects', href: '/projects', kind: 'internal' },
+  { label: 'Experience', href: '/experience', kind: 'internal' },
+] satisfies readonly NavigationItem[];
+
+export function getLinkAttributes(item: NavigationItem): LinkAttributes {
+  if (item.kind === 'external') {
+    return { target: '_blank', rel: 'noreferrer' };
+  }
+
+  if (item.kind === 'download') {
+    return { download: true };
+  }
+
+  return {};
+}
+
+export function isCurrentPage(item: NavigationItem, pathname: string) {
+  return item.kind === 'internal' && item.href === pathname;
+}

--- a/src/lib/siteNavigation.ts
+++ b/src/lib/siteNavigation.ts
@@ -14,6 +14,16 @@ type LinkAttributes = Partial<
   Pick<HTMLAttributes<'a'>, 'target' | 'rel' | 'download'>
 >;
 
+function normalizePathname(value: string) {
+  let normalized = value;
+
+  while (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
 export const primaryNavigation = [
   { label: 'Home', href: '/', kind: 'internal' },
   { label: 'Projects', href: '/projects', kind: 'internal' },
@@ -33,5 +43,9 @@ export function getLinkAttributes(item: NavigationItem): LinkAttributes {
 }
 
 export function isCurrentPage(item: NavigationItem, pathname: string) {
-  return item.kind === 'internal' && item.href === pathname;
+  if (item.kind !== 'internal') {
+    return false;
+  }
+
+  return normalizePathname(item.href) === normalizePathname(pathname);
 }

--- a/src/pages/experience/index.astro
+++ b/src/pages/experience/index.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Experience | Portfolio">
+  <h1>Experience</h1>
+</BaseLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Projects | Portfolio">
+  <h1>Projects</h1>
+</BaseLayout>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -9,6 +9,8 @@
 }
 
 body {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   min-block-size: 100vh;
   background-color: var(--colour-surface-page);
   color: var(--colour-text-primary);

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -8,6 +8,10 @@ html {
   text-size-adjust: 100%;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body,
 h1,
 h2,

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -42,12 +42,18 @@ test('mobile navigation is keyboard operable and restores focus when closed', as
   const menuButton = page.getByRole('button', {
     name: 'Open navigation menu',
   });
+  const menuIcon = page.locator('[data-menu-icon]');
+  const closeIcon = page.locator('[data-close-icon]');
   await expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+  await expect(menuIcon).toBeVisible();
+  await expect(closeIcon).toBeHidden();
 
   await menuButton.focus();
   await page.keyboard.press('Enter');
   await expect(menuButton).toHaveAccessibleName('Close navigation menu');
   await expect(menuButton).toHaveAttribute('aria-expanded', 'true');
+  await expect(menuIcon).toBeHidden();
+  await expect(closeIcon).toBeVisible();
   await expect(
     page
       .getByRole('navigation', { name: 'Primary navigation' })
@@ -57,6 +63,8 @@ test('mobile navigation is keyboard operable and restores focus when closed', as
   await page.keyboard.press('Escape');
   await expect(menuButton).toHaveAccessibleName('Open navigation menu');
   await expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+  await expect(menuIcon).toBeVisible();
+  await expect(closeIcon).toBeHidden();
   await expect(menuButton).toBeFocused();
 });
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,11 +1,20 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test('home provides a keyboard skip link and has no automatically detectable accessibility violations', async ({
+test('home renders the shared semantic shell and has no automatically detectable accessibility violations', async ({
   page,
 }) => {
   await page.goto('/');
 
+  await expect(page.getByRole('banner')).toBeVisible();
+  const primaryNavigation = page.getByRole('navigation', {
+    name: 'Primary navigation',
+  });
+  await expect(primaryNavigation).toBeVisible();
+  await expect(
+    primaryNavigation.getByRole('link', { name: 'Home', exact: true }),
+  ).toHaveAttribute('aria-current', 'page');
+  await expect(page.getByRole('contentinfo')).toBeVisible();
   await expect(
     page.getByRole('heading', { name: 'Portfolio project foundation' }),
   ).toBeVisible();
@@ -18,4 +27,76 @@ test('home provides a keyboard skip link and has no automatically detectable acc
   const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 
   expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test('mobile navigation is keyboard operable and restores focus when closed', async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'mobile-chromium',
+    'Mobile-only interaction',
+  );
+
+  await page.goto('/');
+
+  const menuButton = page.getByRole('button', {
+    name: 'Open navigation menu',
+  });
+  await expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+
+  await menuButton.focus();
+  await page.keyboard.press('Enter');
+  await expect(menuButton).toHaveAccessibleName('Close navigation menu');
+  await expect(menuButton).toHaveAttribute('aria-expanded', 'true');
+  await expect(
+    page
+      .getByRole('navigation', { name: 'Primary navigation' })
+      .getByRole('link', { name: 'Projects', exact: true }),
+  ).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(menuButton).toHaveAccessibleName('Open navigation menu');
+  await expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+  await expect(menuButton).toBeFocused();
+});
+
+test('top-level routes expose their matching current page in primary navigation', async ({
+  page,
+}) => {
+  await page.goto('/projects');
+
+  const primaryNavigation = page.getByRole('navigation', {
+    name: 'Primary navigation',
+  });
+  await expect(
+    primaryNavigation.getByRole('link', { name: 'Projects', exact: true }),
+  ).toHaveAttribute('aria-current', 'page');
+  await expect(
+    primaryNavigation.getByRole('link', { name: 'Home', exact: true }),
+  ).not.toHaveAttribute('aria-current');
+});
+
+test('primary navigation remains visible without JavaScript', async ({
+  browser,
+  baseURL,
+}) => {
+  if (!baseURL) {
+    throw new Error('Playwright baseURL is required for the no-JavaScript check.');
+  }
+
+  const context = await browser.newContext({
+    baseURL,
+    javaScriptEnabled: false,
+  });
+  const page = await context.newPage();
+
+  await page.goto('/');
+
+  await expect(
+    page
+      .getByRole('navigation', { name: 'Primary navigation' })
+      .getByRole('link', { name: 'Experience', exact: true }),
+  ).toBeVisible();
+
+  await context.close();
 });

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,5 +1,13 @@
 import AxeBuilder from '@axe-core/playwright';
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+async function openCompactNavigationIfVisible(page: Page) {
+  const menuButton = page.locator('[data-menu-toggle]');
+
+  if (await menuButton.isVisible()) {
+    await menuButton.click();
+  }
+}
 
 test('home renders the shared semantic shell and has no automatically detectable accessibility violations', async ({
   page,
@@ -10,6 +18,13 @@ test('home renders the shared semantic shell and has no automatically detectable
   const primaryNavigation = page.getByRole('navigation', {
     name: 'Primary navigation',
   });
+
+  await page.keyboard.press('Tab');
+  const skipLink = page.getByRole('link', { name: 'Skip to main content' });
+  await expect(skipLink).toBeFocused();
+  await expect(skipLink).toHaveAttribute('href', '#main-content');
+
+  await openCompactNavigationIfVisible(page);
   await expect(primaryNavigation).toBeVisible();
   await expect(
     primaryNavigation.getByRole('link', { name: 'Home', exact: true }),
@@ -18,11 +33,6 @@ test('home renders the shared semantic shell and has no automatically detectable
   await expect(
     page.getByRole('heading', { name: 'Portfolio project foundation' }),
   ).toBeVisible();
-
-  await page.keyboard.press('Tab');
-  const skipLink = page.getByRole('link', { name: 'Skip to main content' });
-  await expect(skipLink).toBeFocused();
-  await expect(skipLink).toHaveAttribute('href', '#main-content');
 
   const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 
@@ -39,9 +49,7 @@ test('mobile navigation is keyboard operable and restores focus when closed', as
 
   await page.goto('/');
 
-  const menuButton = page.getByRole('button', {
-    name: 'Open navigation menu',
-  });
+  const menuButton = page.locator('[data-menu-toggle]');
   const menuIcon = page.locator('[data-menu-icon]');
   const closeIcon = page.locator('[data-close-icon]');
   await expect(menuButton).toHaveAttribute('aria-expanded', 'false');
@@ -72,6 +80,7 @@ test('top-level routes expose their matching current page in primary navigation'
   page,
 }) => {
   await page.goto('/projects');
+  await openCompactNavigationIfVisible(page);
 
   const primaryNavigation = page.getByRole('navigation', {
     name: 'Primary navigation',

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -98,7 +98,9 @@ test('primary navigation remains visible without JavaScript', async ({
   baseURL,
 }) => {
   if (!baseURL) {
-    throw new Error('Playwright baseURL is required for the no-JavaScript check.');
+    throw new Error(
+      'Playwright baseURL is required for the no-JavaScript check.',
+    );
   }
 
   const context = await browser.newContext({

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -79,7 +79,7 @@ test('mobile navigation is keyboard operable and restores focus when closed', as
 test('top-level routes expose their matching current page in primary navigation', async ({
   page,
 }) => {
-  await page.goto('/projects');
+  await page.goto('/projects/');
   await openCompactNavigationIfVisible(page);
 
   const primaryNavigation = page.getByRole('navigation', {


### PR DESCRIPTION
## Summary

Implements PT-37 shared application shell and responsive navigation.

## Changes

- Adds reusable Astro `SiteHeader` and `SiteFooter` components.
- Composes the shared shell through `BaseLayout`.
- Adds responsive desktop and mobile navigation.
- Preserves a usable no-JavaScript navigation baseline.
- Adds keyboard support, `Escape` handling, focus restoration, and `aria-expanded`.
- Adds exact-route `aria-current="page"` handling.
- Adds typed navigation items with internal, external, and download link kinds.
- Adds minimal `/projects` and `/experience` route shells.
- Uses inline SVG menu and close icons without adding dependencies.
- Keeps component CSS scoped inside Astro files.
- Documents CSS ownership and recommended model routing conventions.

## Architecture

- Astro-first static rendering.
- Progressive enhancement with a small local navigation script.
- No React island, SPA router, global React root, or global state.
- Mobile navigation remains inline and does not use a modal, drawer, or focus trap.
- Global CSS is limited to reset, tokens, base styles, accessibility helpers, and shared conventions.

## Accessibility

- Semantic header, navigation, main, and footer landmarks.
- Skip link reaches `#main-content`.
- Mobile navigation is keyboard operable.
- Menu state is exposed through `aria-expanded`.
- Menu and close icons are decorative with `aria-hidden="true"`.
- Current location is communicated through `aria-current` and a non-colour visual treatment.
- Focus-visible styling remains distinct from hover.
- `[hidden]` is enforced globally so hidden controls and icons cannot be exposed by SVG display rules.

## Validation

Run locally:

- `pnpm check`
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:e2e`
- `pnpm test:site`

## Scope

Final page content, verified external profile URLs, and the CV asset remain outside this ticket until their content dependencies are available.