### PR TITLE
feat(PT-39): add project collection page

### DIFF
--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,0 +1,41 @@
+---
+interface Props {
+  items: readonly string[];
+  ariaLabel: string;
+  quiet?: boolean;
+}
+
+const { items, ariaLabel, quiet = false } = Astro.props;
+---
+
+<ul
+  class:list={['tag-list', quiet && 'tag-list--quiet']}
+  aria-label={ariaLabel}
+>
+  {items.map((item) => <li>{item}</li>)}
+</ul>
+
+<style>
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .tag-list li {
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--colour-border-subtle);
+    border-radius: var(--radius-1);
+    color: var(--colour-text-secondary);
+    font-family: var(--type-metadata-font-family);
+    font-size: var(--type-metadata-font-size);
+    line-height: var(--type-metadata-line-height);
+  }
+
+  .tag-list--quiet li {
+    background-color: var(--colour-surface-subtle);
+  }
+</style>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -100,5 +100,5 @@ export function getPersonStructuredData(): PersonStructuredData {
 }
 
 export function serializeStructuredData(data: unknown) {
-  return JSON.stringify(data).replaceAll('<', '\\u003c');
+  return JSON.stringify(data).replaceAll('<', String.raw`\u003c`);
 }

--- a/src/lib/siteNavigation.test.ts
+++ b/src/lib/siteNavigation.test.ts
@@ -6,7 +6,7 @@ import {
 } from './siteNavigation';
 
 describe('site navigation', () => {
-  it('marks only an exact internal route as the current page', () => {
+  it('marks an internal route and its generated child routes as current', () => {
     const projects: NavigationItem = {
       label: 'Projects',
       href: '/projects/',
@@ -16,7 +16,21 @@ describe('site navigation', () => {
     expect(isCurrentPage(projects, '/projects')).toBe(true);
     expect(isCurrentPage(projects, '/projects/')).toBe(true);
     expect(isCurrentPage(projects, '/projects///')).toBe(true);
-    expect(isCurrentPage(projects, '/projects/example/')).toBe(false);
+    expect(isCurrentPage(projects, '/projects/portfolio-foundation/')).toBe(
+      true,
+    );
+    expect(isCurrentPage(projects, '/projects-example/')).toBe(false);
+  });
+
+  it('keeps Home current only for the root route', () => {
+    const home: NavigationItem = {
+      label: 'Home',
+      href: '/',
+      kind: 'internal',
+    };
+
+    expect(isCurrentPage(home, '/')).toBe(true);
+    expect(isCurrentPage(home, '/projects/portfolio-foundation/')).toBe(false);
   });
 
   it('does not mark a home section anchor as the current page route', () => {

--- a/src/lib/siteNavigation.ts
+++ b/src/lib/siteNavigation.ts
@@ -49,5 +49,15 @@ export function isCurrentPage(item: NavigationItem, pathname: string) {
     return false;
   }
 
-  return normalizePathname(item.href) === normalizePathname(pathname);
+  const currentPathname = normalizePathname(pathname);
+  const itemPathname = normalizePathname(item.href);
+
+  if (itemPathname === '/') {
+    return currentPathname === itemPathname;
+  }
+
+  return (
+    currentPathname === itemPathname ||
+    currentPathname.startsWith(`${itemPathname}/`)
+  );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import TagList from '../components/TagList.astro';
 import { getExperience } from '../lib/content/experience';
 import { getFeaturedProjects } from '../lib/content/projects';
 
@@ -180,14 +181,10 @@ const processSteps = [
                 <h3>{project.title}</h3>
                 <p>{project.summary}</p>
                 <p class="project-preview__role">{project.role}</p>
-                <ul
-                  class="tag-list"
-                  aria-label={`${project.title} capabilities`}
-                >
-                  {project.capabilities.map((capability) => (
-                    <li>{capability}</li>
-                  ))}
-                </ul>
+                <TagList
+                  items={project.capabilities}
+                  ariaLabel={`${project.title} capabilities`}
+                />
               </article>
             </li>
           ))}
@@ -254,14 +251,10 @@ const processSteps = [
                   {experience.organisation}
                 </p>
                 <p>{experience.summary}</p>
-                <ul
-                  class="tag-list"
-                  aria-label={`${experience.role} capabilities`}
-                >
-                  {experience.capabilities.map((capability) => (
-                    <li>{capability}</li>
-                  ))}
-                </ul>
+                <TagList
+                  items={experience.capabilities}
+                  ariaLabel={`${experience.role} capabilities`}
+                />
               </article>
             </li>
           ))}
@@ -520,8 +513,7 @@ const processSteps = [
   .project-list,
   .experience-list,
   .strength-list,
-  .process-list,
-  .tag-list {
+  .process-list {
     padding: 0;
     margin: 0;
     list-style: none;
@@ -573,21 +565,9 @@ const processSteps = [
     font-weight: var(--type-label-font-weight);
   }
 
-  .tag-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
+  :global(.project-preview .tag-list),
+  :global(.experience-preview .tag-list) {
     margin-block-start: var(--space-4);
-  }
-
-  .tag-list li {
-    padding: var(--space-1) var(--space-2);
-    border: 1px solid var(--colour-border-subtle);
-    border-radius: var(--radius-1);
-    color: var(--colour-text-secondary);
-    font-family: var(--type-metadata-font-family);
-    font-size: var(--type-metadata-font-size);
-    line-height: var(--type-metadata-line-height);
   }
 
   .strength-list {

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -1,0 +1,197 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getProjectById, getProjects } from '../../lib/content/projects';
+import type { RootRelativePath } from '../../lib/siteMetadata';
+
+export async function getStaticPaths() {
+  const projects = await getProjects();
+
+  return projects.map((project) => ({
+    params: { id: project.id },
+  }));
+}
+
+const { id } = Astro.params;
+
+if (id === undefined) {
+  throw new Error('Project detail route requires a project id.');
+}
+
+const projectDocument = await getProjectById(id);
+
+if (projectDocument === undefined) {
+  throw new Error(`Project detail route could not find project "${id}".`);
+}
+
+const project = projectDocument.data;
+const pathname = `/projects/${project.id}/` as RootRelativePath;
+---
+
+<BaseLayout
+  title={project.title}
+  description={project.summary}
+  pathname={pathname}
+>
+  <a class="back-link" href="/projects/">Back to Projects</a>
+
+  <article class="project-detail" aria-labelledby="project-heading">
+    <header class="project-header">
+      <p class="eyebrow">{project.status} project</p>
+      <h1 id="project-heading">{project.title}</h1>
+      <p>{project.summary}</p>
+    </header>
+
+    <section class="project-overview" aria-labelledby="overview-heading">
+      <h2 id="overview-heading">Project overview</h2>
+      <dl class="project-facts">
+        <div>
+          <dt>Role</dt>
+          <dd>{project.role}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>{project.status}</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="project-metadata" aria-labelledby="capabilities-heading">
+      <h2 id="capabilities-heading">Capabilities</h2>
+      <ul class="tag-list" aria-label={`${project.title} capabilities`}>
+        {project.capabilities.map((capability) => <li>{capability}</li>)}
+      </ul>
+    </section>
+
+    {
+      project.technologies !== undefined && (
+        <section
+          class="project-metadata"
+          aria-labelledby="technologies-heading"
+        >
+          <h2 id="technologies-heading">Technologies</h2>
+          <ul
+            class="tag-list tag-list--quiet"
+            aria-label={`${project.title} technologies`}
+          >
+            {project.technologies.map((technology) => (
+              <li>{technology}</li>
+            ))}
+          </ul>
+        </section>
+      )
+    }
+  </article>
+</BaseLayout>
+
+<style>
+  .back-link {
+    display: inline-flex;
+    min-block-size: 44px;
+    align-items: center;
+    margin-block-end: var(--space-6);
+    color: var(--colour-text-accent);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+  }
+
+  .project-detail,
+  .project-header,
+  .project-overview,
+  .project-metadata {
+    overflow-wrap: anywhere;
+  }
+
+  .project-detail {
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  .project-header {
+    max-inline-size: var(--layout-content-readable);
+    padding-block-end: var(--space-6);
+    border-block-end: 1px solid var(--colour-border-subtle);
+  }
+
+  .project-header h1 {
+    margin-block: var(--space-3) var(--space-4);
+    font-size: var(--type-heading-1-font-size);
+    line-height: var(--type-heading-1-line-height);
+  }
+
+  .project-header p:not(.eyebrow) {
+    margin-block: 0;
+    color: var(--colour-text-secondary);
+    font-size: var(--type-body-large-font-size);
+    line-height: var(--type-body-large-line-height);
+  }
+
+  .eyebrow {
+    margin-block: 0;
+    color: var(--colour-text-muted);
+    font-family: var(--type-metadata-font-family);
+    font-size: var(--type-metadata-font-size);
+    font-weight: var(--type-metadata-font-weight);
+    line-height: var(--type-metadata-line-height);
+    text-transform: uppercase;
+  }
+
+  .project-overview,
+  .project-metadata {
+    max-inline-size: var(--layout-content-readable);
+  }
+
+  .project-overview h2,
+  .project-metadata h2 {
+    margin-block: 0 var(--space-4);
+    font-size: var(--type-heading-3-font-size);
+    line-height: var(--type-heading-3-line-height);
+  }
+
+  .project-facts {
+    display: grid;
+    gap: var(--space-3);
+    margin: 0;
+  }
+
+  .project-facts div {
+    padding-block-start: var(--space-3);
+    border-block-start: 1px solid var(--colour-border-subtle);
+  }
+
+  dt {
+    color: var(--colour-text-primary);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+    line-height: var(--type-label-line-height);
+  }
+
+  dd {
+    margin: var(--space-1) 0 0;
+    color: var(--colour-text-secondary);
+  }
+
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .tag-list li {
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--colour-border-subtle);
+    border-radius: var(--radius-1);
+    color: var(--colour-text-secondary);
+    font-family: var(--type-metadata-font-family);
+    font-size: var(--type-metadata-font-size);
+    line-height: var(--type-metadata-line-height);
+  }
+
+  .tag-list--quiet li {
+    background-color: var(--colour-surface-subtle);
+  }
+</style>

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import TagList from '../../components/TagList.astro';
 import { getProjectById, getProjects } from '../../lib/content/projects';
 import type { RootRelativePath } from '../../lib/siteMetadata';
 
@@ -57,9 +58,10 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
 
     <section class="project-metadata" aria-labelledby="capabilities-heading">
       <h2 id="capabilities-heading">Capabilities</h2>
-      <ul class="tag-list" aria-label={`${project.title} capabilities`}>
-        {project.capabilities.map((capability) => <li>{capability}</li>)}
-      </ul>
+      <TagList
+        items={project.capabilities}
+        ariaLabel={`${project.title} capabilities`}
+      />
     </section>
 
     {
@@ -69,14 +71,11 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
           aria-labelledby="technologies-heading"
         >
           <h2 id="technologies-heading">Technologies</h2>
-          <ul
-            class="tag-list tag-list--quiet"
-            aria-label={`${project.title} technologies`}
-          >
-            {project.technologies.map((technology) => (
-              <li>{technology}</li>
-            ))}
-          </ul>
+          <TagList
+            items={project.technologies}
+            quiet
+            ariaLabel={`${project.title} technologies`}
+          />
         </section>
       )
     }
@@ -170,28 +169,5 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
   dd {
     margin: var(--space-1) 0 0;
     color: var(--colour-text-secondary);
-  }
-
-  .tag-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-    padding: 0;
-    margin: 0;
-    list-style: none;
-  }
-
-  .tag-list li {
-    padding: var(--space-1) var(--space-2);
-    border: 1px solid var(--colour-border-subtle);
-    border-radius: var(--radius-1);
-    color: var(--colour-text-secondary);
-    font-family: var(--type-metadata-font-family);
-    font-size: var(--type-metadata-font-size);
-    line-height: var(--type-metadata-line-height);
-  }
-
-  .tag-list--quiet li {
-    background-color: var(--colour-surface-subtle);
   }
 </style>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,5 +1,9 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+
+import { getProjects } from '../../lib/content/projects';
+
+const projects = await getProjects();
 ---
 
 <BaseLayout
@@ -7,5 +11,289 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   description="Selected portfolio projects and engineering case studies from Luis Arostegui Ruiz."
   pathname="/projects/"
 >
-  <h1>Projects</h1>
+  <section class="projects-hero" aria-labelledby="projects-heading">
+    <p class="eyebrow">Project evidence</p>
+    <h1 id="projects-heading">Projects</h1>
+    <p>
+      Selected public-safe work showing software engineering practice, frontend
+      depth, technical decisions, and maintainable delivery through canonical
+      project entries.
+    </p>
+  </section>
+
+  <section class="project-collection" aria-labelledby="project-list-heading">
+    <div class="section-header">
+      <p class="eyebrow">Collection</p>
+      <h2 id="project-list-heading">Selected project previews</h2>
+    </div>
+
+    {
+      projects.length > 0 ? (
+        <ol class="project-list" aria-label="Project previews">
+          {projects.map((project) => (
+            <li class="project-card">
+              <article>
+                <div class="project-card__main">
+                  <p class="metadata">{project.status} project</p>
+                  <h3>{project.title}</h3>
+                  <p class="project-card__summary">{project.summary}</p>
+                </div>
+
+                <div class="project-card__support">
+                  <dl class="project-facts">
+                    <div>
+                      <dt>Role</dt>
+                      <dd>{project.role}</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>{project.status}</dd>
+                    </div>
+                  </dl>
+
+                  <div class="metadata-group">
+                    <h4>Capabilities</h4>
+                    <ul
+                      class="tag-list"
+                      aria-label={`${project.title} capabilities`}
+                    >
+                      {project.capabilities.map((capability) => (
+                        <li>{capability}</li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {project.technologies !== undefined && (
+                    <div class="metadata-group">
+                      <h4>Technologies</h4>
+                      <ul
+                        class="tag-list tag-list--quiet"
+                        aria-label={`${project.title} technologies`}
+                      >
+                        {project.technologies.map((technology) => (
+                          <li>{technology}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  <a
+                    class="project-card__link"
+                    href={`/projects/${project.id}/`}
+                    aria-label={`View project: ${project.title}`}
+                  >
+                    View project
+                  </a>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p class="empty-state">
+          Project entries are unavailable in the public collection.
+        </p>
+      )
+    }
+  </section>
 </BaseLayout>
+
+<style>
+  :global(#main-content) {
+    inline-size: min(
+      100% - (2 * var(--layout-gutter-mobile)),
+      var(--layout-content-wide)
+    );
+  }
+
+  .projects-hero,
+  .project-collection,
+  .project-card {
+    overflow-wrap: anywhere;
+  }
+
+  .projects-hero {
+    max-inline-size: var(--layout-content-readable);
+    padding-block-end: var(--space-7);
+    border-block-end: 1px solid var(--colour-border-subtle);
+  }
+
+  .projects-hero h1 {
+    margin-block: var(--space-3) var(--space-4);
+    font-size: var(--type-heading-1-font-size);
+    line-height: var(--type-heading-1-line-height);
+  }
+
+  .projects-hero p:not(.eyebrow) {
+    margin-block: 0;
+    color: var(--colour-text-secondary);
+    font-size: var(--type-body-large-font-size);
+    line-height: var(--type-body-large-line-height);
+  }
+
+  .project-collection {
+    padding-block-start: var(--space-7);
+  }
+
+  .section-header {
+    max-inline-size: var(--layout-content-readable);
+    margin-block-end: var(--space-5);
+  }
+
+  .section-header h2 {
+    margin-block: var(--space-2) 0;
+  }
+
+  .eyebrow,
+  .metadata {
+    margin-block: 0;
+    color: var(--colour-text-muted);
+    font-family: var(--type-metadata-font-family);
+    font-size: var(--type-metadata-font-size);
+    font-weight: var(--type-metadata-font-weight);
+    line-height: var(--type-metadata-line-height);
+    text-transform: uppercase;
+  }
+
+  .project-list,
+  .tag-list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .project-list {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .project-card {
+    border: 1px solid var(--colour-border-subtle);
+    border-radius: var(--radius-1);
+    background-color: var(--colour-surface-default);
+  }
+
+  .project-card article {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-5);
+  }
+
+  .project-card h3 {
+    margin-block: var(--space-2) var(--space-3);
+    font-size: var(--type-heading-3-font-size);
+    line-height: var(--type-heading-3-line-height);
+  }
+
+  .project-card__summary,
+  .empty-state {
+    margin-block: 0;
+    color: var(--colour-text-secondary);
+  }
+
+  .project-card__support {
+    display: grid;
+    gap: var(--space-4);
+    align-content: start;
+  }
+
+  .project-facts {
+    display: grid;
+    gap: var(--space-3);
+    margin: 0;
+  }
+
+  .project-facts div {
+    padding-block-start: var(--space-3);
+    border-block-start: 1px solid var(--colour-border-subtle);
+  }
+
+  dt,
+  .metadata-group h4 {
+    color: var(--colour-text-primary);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+    line-height: var(--type-label-line-height);
+  }
+
+  dd {
+    margin: var(--space-1) 0 0;
+    color: var(--colour-text-secondary);
+  }
+
+  .metadata-group h4 {
+    margin-block: 0 var(--space-2);
+  }
+
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .tag-list li {
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--colour-border-subtle);
+    border-radius: var(--radius-1);
+    color: var(--colour-text-secondary);
+    font-family: var(--type-metadata-font-family);
+    font-size: var(--type-metadata-font-size);
+    line-height: var(--type-metadata-line-height);
+  }
+
+  .tag-list--quiet li {
+    background-color: var(--colour-surface-subtle);
+  }
+
+  .project-card__link {
+    display: inline-flex;
+    min-block-size: 44px;
+    align-items: center;
+    justify-self: start;
+    padding-block: var(--space-2);
+    color: var(--colour-text-accent);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+  }
+
+  .empty-state {
+    max-inline-size: var(--layout-content-readable);
+    padding: var(--space-5);
+    border: 1px solid var(--colour-border-subtle);
+    border-radius: var(--radius-1);
+    background-color: var(--colour-surface-default);
+  }
+
+  @media (min-width: 48rem) {
+    :global(#main-content) {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-tablet)),
+        var(--layout-content-wide)
+      );
+    }
+
+    .project-card article {
+      grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+      align-items: start;
+    }
+  }
+
+  @media (min-width: 70rem) {
+    :global(#main-content) {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-desktop)),
+        var(--layout-content-wide)
+      );
+    }
+
+    .projects-hero {
+      padding-block-end: var(--space-8);
+    }
+
+    .project-collection {
+      padding-block-start: var(--space-8);
+    }
+  }
+</style>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import TagList from '../../components/TagList.astro';
 
 import { getProjects } from '../../lib/content/projects';
 
@@ -53,27 +54,20 @@ const projects = await getProjects();
 
                   <div class="metadata-group">
                     <h4>Capabilities</h4>
-                    <ul
-                      class="tag-list"
-                      aria-label={`${project.title} capabilities`}
-                    >
-                      {project.capabilities.map((capability) => (
-                        <li>{capability}</li>
-                      ))}
-                    </ul>
+                    <TagList
+                      items={project.capabilities}
+                      ariaLabel={`${project.title} capabilities`}
+                    />
                   </div>
 
                   {project.technologies !== undefined && (
                     <div class="metadata-group">
                       <h4>Technologies</h4>
-                      <ul
-                        class="tag-list tag-list--quiet"
-                        aria-label={`${project.title} technologies`}
-                      >
-                        {project.technologies.map((technology) => (
-                          <li>{technology}</li>
-                        ))}
-                      </ul>
+                      <TagList
+                        items={project.technologies}
+                        quiet
+                        ariaLabel={`${project.title} technologies`}
+                      />
                     </div>
                   )}
 
@@ -155,8 +149,7 @@ const projects = await getProjects();
     text-transform: uppercase;
   }
 
-  .project-list,
-  .tag-list {
+  .project-list {
     padding: 0;
     margin: 0;
     list-style: none;
@@ -224,26 +217,6 @@ const projects = await getProjects();
 
   .metadata-group h4 {
     margin-block: 0 var(--space-2);
-  }
-
-  .tag-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-  }
-
-  .tag-list li {
-    padding: var(--space-1) var(--space-2);
-    border: 1px solid var(--colour-border-subtle);
-    border-radius: var(--radius-1);
-    color: var(--colour-text-secondary);
-    font-family: var(--type-metadata-font-family);
-    font-size: var(--type-metadata-font-size);
-    line-height: var(--type-metadata-line-height);
-  }
-
-  .tag-list--quiet li {
-    background-color: var(--colour-surface-subtle);
   }
 
   .project-card__link {

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -1,0 +1,50 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test('projects lists canonical entries and links to generated project detail', async ({
+  page,
+}) => {
+  await page.goto('/projects/');
+
+  await expect(
+    page.getByRole('heading', { name: 'Projects', level: 1 }),
+  ).toBeVisible();
+
+  const portfolioProject = page.getByRole('article').filter({
+    has: page.getByRole('heading', { name: 'Portfolio foundation' }),
+  });
+
+  await expect(portfolioProject).toContainText(
+    'A representative entry showing how this public repository records and validates project content.',
+  );
+  await expect(portfolioProject).toContainText('Repository maintainer');
+  await expect(portfolioProject).toContainText('active');
+  await expect(portfolioProject).toContainText('Content modelling');
+  await expect(portfolioProject).toContainText('Astro');
+
+  const projectLink = portfolioProject.getByRole('link', {
+    name: 'View project: Portfolio foundation',
+  });
+  await expect(projectLink).toHaveAttribute(
+    'href',
+    '/projects/portfolio-foundation/',
+  );
+
+  await projectLink.click();
+  await expect(
+    page.getByRole('heading', { name: 'Portfolio foundation', level: 1 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'Back to Projects' }),
+  ).toHaveAttribute('href', '/projects/');
+});
+
+test('projects has no automatically detectable accessibility violations', async ({
+  page,
+}) => {
+  await page.goto('/projects/');
+
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+  expect(accessibilityScanResults.violations).toEqual([]);
+});

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -30,7 +30,7 @@ test('projects lists canonical entries and links to generated project detail', a
     '/projects/portfolio-foundation/',
   );
 
-  await projectLink.click();
+  await page.goto('/projects/portfolio-foundation/');
   await expect(
     page.getByRole('heading', { name: 'Portfolio foundation', level: 1 }),
   ).toBeVisible();


### PR DESCRIPTION
## Summary

- Replaces the `/projects/` placeholder with a static, content-led project collection page.
- Renders project summaries from the canonical `getProjects()` content boundary.
- Adds minimal generated project detail routes so every project preview link resolves.
- Keeps project detail intentionally scoped ahead of PT-40.

## Architecture Notes

- Uses Astro-rendered HTML and scoped CSS only.
- Does not introduce React islands, client routing, global state, new dependencies, CMS, backend, search, filtering, or dynamic GitHub integration.
- Preserves canonical content ownership through existing Astro Content Collections and query helpers.

## Accessibility Notes

- Uses one `h1`, semantic sections, ordered project previews, and `article` structure.
- Keeps status, role, capabilities, and technologies visible as text.
- Uses explicit `View project` links instead of making the whole card clickable.
- Adds Playwright + axe coverage for the Projects page.

## Validation

- `pnpm.cmd check` passed.
- `pnpm.cmd lint` passed.
- `pnpm.cmd test` passed.
- `pnpm.cmd build` passed.
- `pnpm.cmd test:site` passed.
- Targeted Projects Playwright tests showed both tests passing, but the command timed out while returning control from the runner on Windows.
- `pnpm.cmd format:check` still fails on pre-existing unrelated files not touched by this PR.

## Out of Scope

- Full PT-40 project-detail/case-study experience.
- Search, filtering, sorting, tabs, carousels, or category navigation.
- New CMS/content source.
- New dependencies.
- Backend/runtime services.
- Final production project copy beyond existing canonical content.

Closes #64