### PR TITLE
feat(PT-40): create project detail route

### DIFF
--- a/src/content/projects/portfolio-foundation.md
+++ b/src/content/projects/portfolio-foundation.md
@@ -13,6 +13,8 @@ technologies:
   - TypeScript
 publicLinks:
   - https://github.com/LuisArostegui/portfolio
+  - https://github.com/LuisArostegui/portfolio/issues/65
+  - https://github.com/LuisArostegui/portfolio/blob/main/docs/design/projects-design.md
 ---
 
 > Representative validation content for the public content system. This is not final portfolio copy.
@@ -28,6 +30,25 @@ Content must remain local, build-time validated, portable, and safe to publish i
 ## Decisions
 
 Use Markdown for narrative content, concise frontmatter for structured metadata, and project-owned models for presentation-facing queries.
+
+## Technical evidence
+
+This representative content exercises long-form project detail rendering without adding a new runtime or private implementation detail.
+
+```ts
+const projectDetailRouteKeepsContentStatic =
+  'Astro renders project Markdown without introducing a client-side island or backend dependency.';
+const deliberatelyLongPublicSafeEvidenceIdentifier =
+  'portfolio_project_detail_markdown_code_block_local_overflow_validation_without_runtime_hydration_or_backend_dependency';
+```
+
+| Evidence type  | Public-safe purpose                            | Layout risk covered                                                                           |
+| -------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Markdown prose | Shows narrative project context                | Long technical text should wrap without widening the page                                     |
+| Code excerpt   | Exercises a realistic technical evidence block | long_code_should_scroll_inside_the_code_block_without_creating_page_level_horizontal_overflow |
+| Evidence table | Keeps comparison content structured            | table_cells_should_wrap_without_creating_page_level_horizontal_overflow                       |
+
+![Portfolio social preview image](/social-preview.png)
 
 ## Outcome
 

--- a/src/content/projects/portfolio-foundation.md
+++ b/src/content/projects/portfolio-foundation.md
@@ -11,6 +11,8 @@ capabilities:
 technologies:
   - Astro
   - TypeScript
+publicLinks:
+  - https://github.com/LuisArostegui/portfolio
 ---
 
 > Representative validation content for the public content system. This is not final portfolio copy.

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -25,7 +25,19 @@ if (projectDocument === undefined) {
 }
 
 const project = projectDocument.data;
+const Content = projectDocument.Content;
 const pathname = `/projects/${project.id}/` as RootRelativePath;
+
+function formatPublicLinkLabel(link: string): string {
+  const url = new URL(link);
+  const hostname = url.hostname.replace(/^www\./, '');
+
+  if (hostname === 'github.com') {
+    return 'GitHub repository';
+  }
+
+  return `Public evidence on ${hostname}`;
+}
 ---
 
 <BaseLayout
@@ -64,6 +76,10 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
       />
     </section>
 
+    <div class="project-prose">
+      <Content />
+    </div>
+
     {
       project.technologies !== undefined && (
         <section
@@ -79,10 +95,37 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
         </section>
       )
     }
+
+    {
+      project.publicLinks !== undefined && (
+        <section class="project-evidence" aria-labelledby="evidence-heading">
+          <h2 id="evidence-heading">Public evidence</h2>
+          <ul aria-label={`${project.title} public evidence`}>
+            {project.publicLinks.map((link) => (
+              <li>
+                <a href={link}>{formatPublicLinkLabel(link)}</a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )
+    }
+
+    <nav class="project-continuation" aria-label="Project continuation">
+      <h2>Continue exploring</h2>
+      <a href="/projects/">All projects</a>
+    </nav>
   </article>
 </BaseLayout>
 
 <style>
+  :global(#main-content) {
+    inline-size: min(
+      100% - (2 * var(--layout-gutter-mobile)),
+      var(--layout-content-standard)
+    );
+  }
+
   .back-link {
     display: inline-flex;
     min-block-size: 44px;
@@ -97,7 +140,11 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
   .project-detail,
   .project-header,
   .project-overview,
-  .project-metadata {
+  .project-metadata,
+  .project-prose,
+  .project-evidence,
+  .project-continuation {
+    min-inline-size: 0;
     overflow-wrap: anywhere;
   }
 
@@ -136,12 +183,17 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
   }
 
   .project-overview,
-  .project-metadata {
+  .project-metadata,
+  .project-prose,
+  .project-evidence,
+  .project-continuation {
     max-inline-size: var(--layout-content-readable);
   }
 
   .project-overview h2,
-  .project-metadata h2 {
+  .project-metadata h2,
+  .project-evidence h2,
+  .project-continuation h2 {
     margin-block: 0 var(--space-4);
     font-size: var(--type-heading-3-font-size);
     line-height: var(--type-heading-3-line-height);
@@ -169,5 +221,147 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
   dd {
     margin: var(--space-1) 0 0;
     color: var(--colour-text-secondary);
+  }
+
+  .project-prose {
+    color: var(--colour-text-secondary);
+  }
+
+  .project-prose :global(*) {
+    max-inline-size: 100%;
+  }
+
+  .project-prose :global(* + *) {
+    margin-block-start: var(--space-4);
+  }
+
+  .project-prose :global(h2),
+  .project-prose :global(h3),
+  .project-prose :global(h4) {
+    color: var(--colour-text-primary);
+    overflow-wrap: anywhere;
+  }
+
+  .project-prose :global(h2) {
+    margin-block: var(--space-6) var(--space-3);
+    font-size: var(--type-heading-3-font-size);
+    line-height: var(--type-heading-3-line-height);
+  }
+
+  .project-prose :global(h3) {
+    margin-block: var(--space-5) var(--space-3);
+    font-size: var(--type-body-large-font-size);
+    line-height: var(--type-body-large-line-height);
+  }
+
+  .project-prose :global(p),
+  .project-prose :global(li),
+  .project-prose :global(blockquote),
+  .project-prose :global(td),
+  .project-prose :global(th) {
+    overflow-wrap: anywhere;
+  }
+
+  .project-prose :global(p),
+  .project-prose :global(ul),
+  .project-prose :global(ol),
+  .project-prose :global(blockquote) {
+    margin-block-end: 0;
+  }
+
+  .project-prose :global(blockquote) {
+    padding-inline-start: var(--space-4);
+    border-inline-start: 3px solid var(--colour-border-accent);
+    color: var(--colour-text-muted);
+  }
+
+  .project-prose :global(pre) {
+    max-inline-size: 100%;
+    padding: var(--space-4);
+    overflow-x: auto;
+    border: 1px solid var(--colour-border-subtle);
+    border-radius: var(--radius-1);
+    background-color: var(--colour-surface-default);
+  }
+
+  .project-prose :global(pre code) {
+    overflow-wrap: normal;
+    white-space: pre;
+  }
+
+  .project-prose :global(:not(pre) > code) {
+    padding: 0 var(--space-1);
+    border-radius: var(--radius-0);
+    background-color: var(--colour-surface-subtle);
+    overflow-wrap: anywhere;
+  }
+
+  .project-prose :global(table) {
+    display: block;
+    max-inline-size: 100%;
+    overflow-x: auto;
+    border-collapse: collapse;
+  }
+
+  .project-prose :global(th),
+  .project-prose :global(td) {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--colour-border-subtle);
+    text-align: start;
+  }
+
+  .project-prose :global(img),
+  .project-prose :global(video),
+  .project-prose :global(canvas),
+  .project-prose :global(svg),
+  .project-prose :global(iframe) {
+    block-size: auto;
+    max-inline-size: 100%;
+  }
+
+  .project-evidence,
+  .project-continuation {
+    padding-block-start: var(--space-5);
+    border-block-start: 1px solid var(--colour-border-subtle);
+  }
+
+  .project-evidence ul {
+    display: grid;
+    gap: var(--space-3);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .project-evidence a,
+  .project-continuation a {
+    display: inline-flex;
+    min-block-size: 44px;
+    align-items: center;
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+  }
+
+  .project-continuation h2 {
+    margin-block-end: var(--space-2);
+  }
+
+  @media (min-width: 48rem) {
+    :global(#main-content) {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-tablet)),
+        var(--layout-content-standard)
+      );
+    }
+  }
+
+  @media (min-width: 70rem) {
+    :global(#main-content) {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-desktop)),
+        var(--layout-content-standard)
+      );
+    }
   }
 </style>

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -31,9 +31,31 @@ const pathname = `/projects/${project.id}/` as RootRelativePath;
 function formatPublicLinkLabel(link: string): string {
   const url = new URL(link);
   const hostname = url.hostname.replace(/^www\./, '');
+  const [owner, repo, section, ...pathParts] = url.pathname
+    .split('/')
+    .filter(Boolean);
 
   if (hostname === 'github.com') {
-    return 'GitHub repository';
+    if (owner !== undefined && repo !== undefined && section === undefined) {
+      return 'GitHub repository';
+    }
+
+    if (section === 'issues') {
+      return 'GitHub issue';
+    }
+
+    if (section === 'pull') {
+      return 'GitHub pull request';
+    }
+
+    if (
+      (section === 'blob' || section === 'tree') &&
+      pathParts.includes('docs')
+    ) {
+      return 'GitHub documentation';
+    }
+
+    return 'GitHub evidence';
   }
 
   return `Public evidence on ${hostname}`;
@@ -297,9 +319,6 @@ function formatPublicLinkLabel(link: string): string {
   }
 
   .project-prose :global(table) {
-    display: block;
-    max-inline-size: 100%;
-    overflow-x: auto;
     border-collapse: collapse;
   }
 
@@ -307,6 +326,7 @@ function formatPublicLinkLabel(link: string): string {
   .project-prose :global(td) {
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--colour-border-subtle);
+    overflow-wrap: anywhere;
     text-align: start;
   }
 

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -71,6 +71,18 @@ test('project detail renders canonical narrative, evidence, and continuation', a
   await expect(
     page.getByRole('link', { name: 'GitHub repository' }),
   ).toHaveAttribute('href', 'https://github.com/LuisArostegui/portfolio');
+  await expect(
+    page.getByRole('link', { name: 'GitHub issue' }),
+  ).toHaveAttribute(
+    'href',
+    'https://github.com/LuisArostegui/portfolio/issues/65',
+  );
+  await expect(
+    page.getByRole('link', { name: 'GitHub documentation' }),
+  ).toHaveAttribute(
+    'href',
+    'https://github.com/LuisArostegui/portfolio/blob/main/docs/design/projects-design.md',
+  );
 
   await expect(
     page.getByRole('navigation', { name: 'Project continuation' }),
@@ -117,6 +129,13 @@ test('project detail does not introduce page-level horizontal scrolling on mobil
 
   await page.goto('/projects/portfolio-foundation/');
 
+  await expect(
+    page.getByRole('heading', { name: 'Technical evidence' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('img', { name: 'Portfolio social preview image' }),
+  ).toBeVisible();
+
   const hasPageLevelHorizontalScroll = await page.evaluate(
     () =>
       document.documentElement.scrollWidth >
@@ -124,6 +143,39 @@ test('project detail does not introduce page-level horizontal scrolling on mobil
   );
 
   expect(hasPageLevelHorizontalScroll).toBe(false);
+
+  const technicalContentLayout = await page.evaluate(() => {
+    const codeBlock = document.querySelector('.project-prose pre');
+    const table = document.querySelector('.project-prose table');
+    const image = document.querySelector('.project-prose img');
+
+    if (
+      codeBlock === null ||
+      table === null ||
+      image === null ||
+      codeBlock.parentElement === null ||
+      table.parentElement === null ||
+      image.parentElement === null
+    ) {
+      throw new Error('Expected project technical content was not rendered.');
+    }
+
+    return {
+      codeBlockLocallyScrolls:
+        codeBlock.scrollWidth > codeBlock.clientWidth &&
+        codeBlock.clientWidth <= document.documentElement.clientWidth,
+      tableFitsPage: table.scrollWidth <= document.documentElement.clientWidth,
+      imageFitsContainer:
+        image.getBoundingClientRect().width <=
+        image.parentElement.getBoundingClientRect().width,
+    };
+  });
+
+  expect(technicalContentLayout).toEqual({
+    codeBlockLocallyScrolls: true,
+    tableFitsPage: true,
+    imageFitsContainer: true,
+  });
 });
 
 test('projects and project detail have no automatically detectable accessibility violations', async ({

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -39,12 +39,105 @@ test('projects lists canonical entries and links to generated project detail', a
   ).toHaveAttribute('href', '/projects/');
 });
 
-test('projects has no automatically detectable accessibility violations', async ({
+test('project detail renders canonical narrative, evidence, and continuation', async ({
+  page,
+}) => {
+  await page.goto('/projects/portfolio-foundation/');
+
+  await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
+  await expect(
+    page.getByRole('heading', { name: 'Portfolio foundation', level: 1 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Context', level: 2 }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      'The portfolio needs one canonical, reviewable source for project summaries and future case-study prose.',
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Decisions', level: 2 }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      'Use Markdown for narrative content, concise frontmatter for structured metadata, and project-owned models for presentation-facing queries.',
+    ),
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('heading', { name: 'Public evidence', level: 2 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'GitHub repository' }),
+  ).toHaveAttribute('href', 'https://github.com/LuisArostegui/portfolio');
+
+  await expect(
+    page.getByRole('navigation', { name: 'Project continuation' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'All projects' }),
+  ).toHaveAttribute('href', '/projects/');
+});
+
+test('concise project detail omits unavailable optional sections cleanly', async ({
+  page,
+}) => {
+  await page.goto('/projects/content-model-example/');
+
+  await expect(
+    page.getByRole('heading', { name: 'Content model example', level: 1 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Context', level: 2 }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      'Future pages need stable project models without depending directly on Astro collection entries.',
+    ),
+  ).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Technologies' })).toHaveCount(
+    0,
+  );
+  await expect(
+    page.getByRole('heading', { name: 'Public evidence' }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole('link', { name: 'GitHub repository' }),
+  ).toHaveCount(0);
+});
+
+test('project detail does not introduce page-level horizontal scrolling on mobile', async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'mobile-chromium',
+    'Mobile-only responsive check',
+  );
+
+  await page.goto('/projects/portfolio-foundation/');
+
+  const hasPageLevelHorizontalScroll = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth >
+      document.documentElement.clientWidth,
+  );
+
+  expect(hasPageLevelHorizontalScroll).toBe(false);
+});
+
+test('projects and project detail have no automatically detectable accessibility violations', async ({
   page,
 }) => {
   await page.goto('/projects/');
 
-  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+  const projectsScanResults = await new AxeBuilder({ page }).analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(projectsScanResults.violations).toEqual([]);
+
+  await page.goto('/projects/portfolio-foundation/');
+
+  const detailScanResults = await new AxeBuilder({ page }).analyze();
+
+  expect(detailScanResults.violations).toEqual([]);
 });


### PR DESCRIPTION
## Summary

- Complete the existing static Astro project-detail route by rendering canonical Markdown body content from Astro Content Collections.
- Add conditional public evidence links and a clear continuation path back to Projects.
- Extend Playwright coverage for project-detail rendering, optional-section omission, mobile overflow, and axe scans on Projects index plus a project detail page.

## Implementation notes

- Keeps the route Astro-owned and static-first with no React island, new dependency, backend behaviour, search/filtering, or separate case-study route.
- Preserves existing `BaseLayout` metadata wiring for the generated detail pathname.
- Uses the existing `getProjectById` content boundary and returned `Content` component.
- Adds a factual public repository link to the representative portfolio project entry so public evidence is rendered only when canonical content provides it.
- Keeps technologies conditional and secondary to the narrative body.

## Accessibility

- Maintains a single `h1`, wraps the detail in an `article`, uses labelled sections, and keeps all navigation/evidence actions as real links with meaningful text.
- Adds a labelled project-continuation navigation area.
- Adds scoped long-form content CSS for readable width, long text wrapping, responsive media, and local overflow for code and tables.
- Axe scans were run against both `/projects/` and `/projects/portfolio-foundation/`; automated axe results do not prove full WCAG conformance.

## Validation

- `pnpm.cmd check`: passed, 28 files checked with 0 errors, 0 warnings, 0 hints.
- `pnpm.cmd lint`: passed.
- `pnpm.cmd exec prettier --check -- src/pages/projects/[id].astro tests/e2e/projects.spec.ts src/content/projects/portfolio-foundation.md`: passed for changed files.
- `pnpm.cmd format:check`: failed on pre-existing untouched files: `src/components/TagList.astro`, `src/lib/seo.ts`, `src/lib/siteNavigation.test.ts`, `src/lib/siteNavigation.ts`, `src/pages/index.astro`, `src/pages/projects/index.astro`.
- `pnpm.cmd test`: passed, 3 test files and 15 tests.
- `pnpm.cmd build`: passed, 5 static pages generated including both project detail routes.
- `pnpm.cmd test:e2e`: test output reported 20 passing tests and 2 intentional skips, then the command timed out during Playwright web-server teardown on Windows before process exit.
- `pnpm.cmd test:site`: passed, 10 links scanned.

## Scope confirmation

- Did not add React, dependencies, a separate case-study route, search, filtering, backend behaviour, deployment/config changes, or speculative abstractions.
- Kept project content canonical in Astro Content Collections.
- Did not invent production metrics, client details, screenshots, confidential content, or unsupported final claims.

Closes #65