### PR TITLE
Add Codex team template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,42 @@
-# Team
+# Portfolio agent guidance
 
-This repository is a reusable Codex team template. Copy it into a project, adapt the placeholders, and use the same agent workflow across repositories.
+These instructions apply to every task in this repository. Task-specific procedures live under `.agents/skills/`.
 
-## Model Aliases
+## Source of truth
+
+1. The linked GitHub issue defines the requested scope and acceptance criteria.
+2. Accepted architecture decisions in `docs/architecture/decisions/` govern technical choices.
+3. Design and product documents govern approved content, interaction, and presentation requirements.
+4. Existing implementation and tests establish local conventions when they do not conflict with the sources above.
+
+Read the issue and directly relevant governing documents before changing files. Do not invent requirements, product content, visual details, or architectural decisions.
+
+## Architectural boundaries
+
+- Build static-first with Astro. Use React only for a contained interactive island with a real client-side responsibility.
+- Preserve progressive enhancement. A baseline task must remain usable without client JavaScript unless an approved interaction explicitly requires it.
+- Use TypeScript, modern CSS, and the established semantic token system. Do not introduce a CSS framework or design-token system without an approved decision.
+- Keep portfolio content in Git-tracked Astro Content Collections and validate collection data with Zod.
+- Target Cloudflare Workers Static Assets according to ADR-0005. Do not assume Node.js runtime APIs are available in deployed code.
+- Apply the risk-based testing strategy in ADR-0006. Choose the smallest test layer that proves the changed behaviour.
+
+## Working rules
+
+- Keep changes within the issue scope and explain any necessary scope clarification before acting.
+- Reuse an existing component only when responsibility and reuse are real; a visual group alone does not justify a component family.
+- Treat unavailable content or evidence by omitting it cleanly rather than creating placeholder UI.
+- Do not add dependencies, deployment changes, generated output, secrets, or unrelated formatting without explicit scope.
+- For documentation-only tasks, do not add production code, styles, runtime, or test scaffolding.
+- Keep component styles inside `.astro` files by default. Extract CSS only when it is genuinely shared or large enough that separation materially improves readability. Do not create one CSS file per component as a default pattern.
+- Before handoff, inspect the changed files, validate relevant links or checks, and report what was verified and what was not.
+
+## Skills
+
+- Use `portfolio-implementation` for Astro, React islands, TypeScript, CSS, or Content Collection work.
+- Use `portfolio-validation` for tests, accessibility checks, browser validation, or release-readiness work.
+- Use `portfolio-cloudflare` for Workers, Wrangler configuration, or deployment work.
+
+## Model aliases
 
 Use these names as human-facing capability aliases only. Do not use them as technical model IDs.
 
@@ -16,7 +50,17 @@ Technical configuration must use local placeholders or real model IDs from your 
 - `<FAST_MODEL>`
 - `<REVIEW_MODEL>`
 
-## Workflow
+## Recommended model routing
+
+Use these recommendations as guidance, not as mandatory routing rules.
+
+- Sol: architecture decisions, ADRs, repository planning, PR reviews, complex debugging, accessibility design, and large refactors.
+- Terra: feature implementation, tests, documentation tied to implementation, and medium-sized refactors.
+- Luna: mechanical changes, small fixes, renames, formatting, and simple documentation.
+
+## Team workflow
+
+Use the reusable Codex team workflow for complex or parallelizable tasks:
 
 1. Architect reads the issue and existing project context.
 2. Explorer analyzes the repository before implementation starts.
@@ -29,7 +73,9 @@ Technical configuration must use local placeholders or real model IDs from your 
 
 When work can happen in parallel, use separate git worktrees so agents do not overwrite each other.
 
-## Shared Rules
+## Team roles
+
+Shared rules:
 
 - Read the nearest project instructions before editing: `AGENTS.md`, `README.md`, package docs, and relevant issue context.
 - Protect user changes. Never revert unrelated work.
@@ -38,9 +84,7 @@ When work can happen in parallel, use separate git worktrees so agents do not ov
 - Verify changes before claiming they are complete.
 - Report blockers with concrete evidence and suggested next steps.
 
-## Architect
-
-Responsibilities:
+Architect:
 
 - Understand the issue.
 - Define success criteria.
@@ -50,11 +94,7 @@ Responsibilities:
 - Review the final result.
 - Avoid programming except for very small glue changes.
 
-The Architect owns sequencing, risk, and integration.
-
-## Explorer
-
-Responsibilities:
+Explorer:
 
 - Analyze the repository before implementation starts.
 - Identify relevant files, patterns, constraints, and risks.
@@ -62,11 +102,7 @@ Responsibilities:
 - Recommend the smallest viable implementation path.
 - Avoid modifying code.
 
-Explorer output should be concise and actionable.
-
-## Frontend Engineer
-
-Responsibilities:
+Frontend Engineer:
 
 - Implement production code.
 - Follow existing architecture and style.
@@ -74,9 +110,7 @@ Responsibilities:
 - Avoid unrelated refactors.
 - Hand off what changed and what still needs testing.
 
-## QA Engineer
-
-Responsibilities:
+QA Engineer:
 
 - Write and update tests.
 - Cover user-facing behavior and likely regressions.
@@ -84,21 +118,16 @@ Responsibilities:
 - Keep tests focused and maintainable.
 - Report any gaps that cannot be tested locally.
 
-## Reviewer
-
-Responsibilities:
+Reviewer:
 
 - Review architecture.
 - Review clean code.
 - Review accessibility.
 - Review performance.
 - Review test coverage and regression risk.
+- Lead with findings and do not implement changes.
 
-The Reviewer does not implement changes. Findings should lead with severity and include file references when possible.
-
-## Technical Writer
-
-Responsibilities:
+Technical Writer:
 
 - Draft PR descriptions.
 - Draft changelog entries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,108 @@
-# Portfolio agent guidance
+# Team
 
-These instructions apply to every task in this repository. Task-specific procedures live under `.agents/skills/`.
+This repository is a reusable Codex team template. Copy it into a project, adapt the placeholders, and use the same agent workflow across repositories.
 
-## Source of truth
+## Model Aliases
 
-1. The linked GitHub issue defines the requested scope and acceptance criteria.
-2. Accepted architecture decisions in `docs/architecture/decisions/` govern technical choices.
-3. Design and product documents govern approved content, interaction, and presentation requirements.
-4. Existing implementation and tests establish local conventions when they do not conflict with the sources above.
+Use these names as human-facing capability aliases only. Do not use them as technical model IDs.
 
-Read the issue and directly relevant governing documents before changing files. Do not invent requirements, product content, visual details, or architectural decisions.
+- Sol: main architect/orchestrator model with stronger reasoning.
+- Terra: balanced implementer model.
+- Luna: fast and inexpensive support model for exploration, tests, review, and writing.
 
-## Architectural boundaries
+Technical configuration must use local placeholders or real model IDs from your Codex allowlist:
 
-- Build static-first with Astro. Use React only for a contained interactive island with a real client-side responsibility.
-- Preserve progressive enhancement. A baseline task must remain usable without client JavaScript unless an approved interaction explicitly requires it.
-- Use TypeScript, modern CSS, and the established semantic token system. Do not introduce a CSS framework or design-token system without an approved decision.
-- Keep portfolio content in Git-tracked Astro Content Collections and validate collection data with Zod.
-- Target Cloudflare Workers Static Assets according to ADR-0005. Do not assume Node.js runtime APIs are available in deployed code.
-- Apply the risk-based testing strategy in ADR-0006. Choose the smallest test layer that proves the changed behaviour.
+- `<MAIN_MODEL>`
+- `<FAST_MODEL>`
+- `<REVIEW_MODEL>`
 
-## Working rules
+## Workflow
 
-- Keep changes within the issue scope and explain any necessary scope clarification before acting.
-- Reuse an existing component only when responsibility and reuse are real; a visual group alone does not justify a component family.
-- Treat unavailable content or evidence by omitting it cleanly rather than creating placeholder UI.
-- Do not add dependencies, deployment changes, generated output, secrets, or unrelated formatting without explicit scope.
-- For documentation-only tasks, do not add production code, styles, runtime, or test scaffolding.
-- Keep component styles inside `.astro` files by default. Extract CSS only when it is genuinely shared or large enough that separation materially improves readability. Do not create one CSS file per component as a default pattern.
-- Before handoff, inspect the changed files, validate relevant links or checks, and report what was verified and what was not.
+1. Architect reads the issue and existing project context.
+2. Explorer analyzes the repository before implementation starts.
+3. Architect splits the work and assigns focused tasks.
+4. Frontend implements production changes.
+5. QA writes or updates tests.
+6. Reviewer reviews architecture, clean code, accessibility, performance, and regressions.
+7. Writer prepares PR notes, changelog entries, and documentation.
+8. Architect performs final integration and verification.
 
-## Skills
+When work can happen in parallel, use separate git worktrees so agents do not overwrite each other.
 
-- Use `portfolio-implementation` for Astro, React islands, TypeScript, CSS, or Content Collection work.
-- Use `portfolio-validation` for tests, accessibility checks, browser validation, or release-readiness work.
-- Use `portfolio-cloudflare` for Workers, Wrangler configuration, or deployment work.
+## Shared Rules
 
-## Recommended model routing
+- Read the nearest project instructions before editing: `AGENTS.md`, `README.md`, package docs, and relevant issue context.
+- Protect user changes. Never revert unrelated work.
+- Keep edits scoped to the assigned task.
+- Prefer existing project conventions over new abstractions.
+- Verify changes before claiming they are complete.
+- Report blockers with concrete evidence and suggested next steps.
 
-Use these recommendations as guidance, not as mandatory routing rules.
+## Architect
 
-- GPT-5.6 Sol: architecture decisions, ADRs, repository planning, PR reviews,
-  complex debugging, accessibility design, and large refactors.
-- GPT-5.6 Terra: feature implementation, tests, documentation tied to
-  implementation, and medium-sized refactors.
-- GPT-5.6 Luna: mechanical changes, small fixes, renames, formatting, and
-  simple documentation.
+Responsibilities:
+
+- Understand the issue.
+- Define success criteria.
+- Split the work into independent tasks.
+- Decide whether worktrees are needed.
+- Delegate to Explorer before implementation.
+- Review the final result.
+- Avoid programming except for very small glue changes.
+
+The Architect owns sequencing, risk, and integration.
+
+## Explorer
+
+Responsibilities:
+
+- Analyze the repository before implementation starts.
+- Identify relevant files, patterns, constraints, and risks.
+- Explain the current behavior.
+- Recommend the smallest viable implementation path.
+- Avoid modifying code.
+
+Explorer output should be concise and actionable.
+
+## Frontend Engineer
+
+Responsibilities:
+
+- Implement production code.
+- Follow existing architecture and style.
+- Keep components ergonomic, accessible, and responsive.
+- Avoid unrelated refactors.
+- Hand off what changed and what still needs testing.
+
+## QA Engineer
+
+Responsibilities:
+
+- Write and update tests.
+- Cover user-facing behavior and likely regressions.
+- Prefer real behavior over mock behavior.
+- Keep tests focused and maintainable.
+- Report any gaps that cannot be tested locally.
+
+## Reviewer
+
+Responsibilities:
+
+- Review architecture.
+- Review clean code.
+- Review accessibility.
+- Review performance.
+- Review test coverage and regression risk.
+
+The Reviewer does not implement changes. Findings should lead with severity and include file references when possible.
+
+## Technical Writer
+
+Responsibilities:
+
+- Draft PR descriptions.
+- Draft changelog entries.
+- Update documentation.
+- Summarize user-facing impact.
+- Keep writing factual, concise, and tied to verified changes.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,4 +105,3 @@ Responsibilities:
 - Update documentation.
 - Summarize user-facing impact.
 - Keep writing factual, concise, and tied to verified changes.
-

--- a/agents/architect.toml
+++ b/agents/architect.toml
@@ -1,0 +1,5 @@
+model = "<MAIN_MODEL>"
+model_reasoning_effort = "high"
+developer_instructions = """
+Act as the project architect. Read the issue and repository context, define success criteria, split work into focused tasks, decide sequencing, and perform final integration review.
+"""

--- a/agents/explorer.toml
+++ b/agents/explorer.toml
@@ -1,0 +1,5 @@
+model = "<FAST_MODEL>"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Act as the repository explorer. Analyze relevant files, conventions, constraints, risks, and the smallest viable implementation path. Do not modify files.
+"""

--- a/agents/frontend.toml
+++ b/agents/frontend.toml
@@ -1,0 +1,5 @@
+model = "<MAIN_MODEL>"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Act as the frontend implementer. Make focused production changes using existing architecture, semantic HTML, accessible UI, responsive CSS, and project conventions.
+"""

--- a/agents/qa.toml
+++ b/agents/qa.toml
@@ -1,0 +1,5 @@
+model = "<FAST_MODEL>"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Act as the QA engineer. Add or update focused tests for user-facing behavior and likely regressions, then report any gaps that cannot be tested locally.
+"""

--- a/agents/reviewer.toml
+++ b/agents/reviewer.toml
@@ -1,0 +1,5 @@
+model = "<REVIEW_MODEL>"
+model_reasoning_effort = "high"
+developer_instructions = """
+Act as the reviewer. Review architecture, clean code, accessibility, performance, test coverage, and regression risk. Lead with findings and do not implement changes.
+"""

--- a/agents/writer.toml
+++ b/agents/writer.toml
@@ -1,0 +1,5 @@
+model = "<FAST_MODEL>"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Act as the technical writer. Draft concise PR notes, changelog entries, and documentation tied to verified changes and user-facing impact.
+"""

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,19 +5,25 @@ default_subagent_model = "<FAST_MODEL>"
 default_subagent_reasoning_effort = "medium"
 
 [agents.architect]
+description = "Plan complex work, split tasks, manage sequencing, and perform final integration review."
 config_file = "agents/architect.toml"
 
 [agents.explorer]
+description = "Analyze repository context, conventions, risks, and the smallest viable implementation path without editing files."
 config_file = "agents/explorer.toml"
 
 [agents.frontend]
+description = "Implement focused Astro, React island, TypeScript, CSS, and content changes using project conventions."
 config_file = "agents/frontend.toml"
 
 [agents.qa]
+description = "Write or update focused tests and report local verification gaps."
 config_file = "agents/qa.toml"
 
 [agents.reviewer]
+description = "Review architecture, code quality, accessibility, performance, tests, and regression risk without editing files."
 config_file = "agents/reviewer.toml"
 
 [agents.writer]
+description = "Draft concise PR notes, changelog entries, and documentation tied to verified changes."
 config_file = "agents/writer.toml"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,23 @@
+[agents]
+enabled = true
+max_concurrent_threads_per_session = 4
+default_subagent_model = "<FAST_MODEL>"
+default_subagent_reasoning_effort = "medium"
+
+[agents.architect]
+config_file = "agents/architect.toml"
+
+[agents.explorer]
+config_file = "agents/explorer.toml"
+
+[agents.frontend]
+config_file = "agents/frontend.toml"
+
+[agents.qa]
+config_file = "agents/qa.toml"
+
+[agents.reviewer]
+config_file = "agents/reviewer.toml"
+
+[agents.writer]
+config_file = "agents/writer.toml"

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -1,0 +1,25 @@
+# Implementation Prompt
+
+Use this when Architect assigns implementation to Frontend or another implementer.
+
+```text
+Implement the assigned task.
+
+Task:
+<TASK_DESCRIPTION>
+
+Explorer findings:
+<PASTE_EXPLORER_SUMMARY>
+
+Scope:
+- Files likely involved: <FILES>
+- Out of scope: <OUT_OF_SCOPE>
+- Expected behavior: <EXPECTED_BEHAVIOR>
+
+Rules:
+- Follow existing project patterns.
+- Keep the change focused.
+- Protect user changes.
+- Run relevant verification and report results.
+```
+

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -22,4 +22,3 @@ Rules:
 - Protect user changes.
 - Run relevant verification and report results.
 ```
-

--- a/prompts/issue-analysis.md
+++ b/prompts/issue-analysis.md
@@ -20,4 +20,3 @@ Constraints:
 - Ground claims in file references.
 - Keep the answer concise and actionable.
 ```
-

--- a/prompts/issue-analysis.md
+++ b/prompts/issue-analysis.md
@@ -1,0 +1,23 @@
+# Issue Analysis Prompt
+
+Use this with Explorer before implementation starts.
+
+```text
+Analyze this repository for issue: <ISSUE_ID_OR_TITLE>
+
+Context:
+<PASTE_ISSUE_CONTEXT>
+
+Deliver:
+- Current behavior and likely relevant files.
+- Project conventions that matter.
+- Risks and unknowns.
+- Suggested implementation path.
+- Suggested tests.
+
+Constraints:
+- Do not modify files.
+- Ground claims in file references.
+- Keep the answer concise and actionable.
+```
+

--- a/prompts/pr-description.md
+++ b/prompts/pr-description.md
@@ -1,0 +1,21 @@
+# PR Description Prompt
+
+Use this with Writer after final verification.
+
+```text
+Draft a PR description from the current diff and verification output.
+
+Include:
+- Summary.
+- Changes.
+- Tests and verification.
+- Risks or follow-up work.
+
+Inputs:
+- Issue: <ISSUE_LINK_OR_TEXT>
+- Diff summary: <DIFF_SUMMARY>
+- Verification output: <TEST_OUTPUT>
+
+Keep it concise and factual. Do not invent changes.
+```
+

--- a/prompts/pr-description.md
+++ b/prompts/pr-description.md
@@ -18,4 +18,3 @@ Inputs:
 
 Keep it concise and factual. Do not invent changes.
 ```
-

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -1,0 +1,23 @@
+# Review Prompt
+
+Use this with Reviewer after implementation and tests.
+
+```text
+Review the current diff.
+
+Focus:
+- Bugs and regressions.
+- Architecture and maintainability.
+- Accessibility.
+- Performance.
+- Missing or weak tests.
+
+Output:
+- Findings first, ordered by severity.
+- File and line references when possible.
+- Open questions or assumptions.
+- Brief summary only after findings.
+
+Do not implement changes.
+```
+

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -20,4 +20,3 @@ Output:
 
 Do not implement changes.
 ```
-

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/cleanup-worktrees.sh [--dry-run] [worktrees-dir]
+
+Examples:
+  scripts/cleanup-worktrees.sh --dry-run
+  scripts/cleanup-worktrees.sh ../worktrees
+
+Removes git worktrees under the chosen directory only when their working tree is clean.
+USAGE
+}
+
+dry_run=false
+worktrees_dir="../worktrees"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      worktrees_dir="$1"
+      shift
+      ;;
+  esac
+done
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "error: run this script inside a git repository" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [[ ! -d "$worktrees_dir" ]]; then
+  printf 'no worktrees directory found: %s\n' "$worktrees_dir"
+  exit 0
+fi
+
+while IFS= read -r -d '' path; do
+  if [[ ! -d "$path/.git" && ! -f "$path/.git" ]]; then
+    continue
+  fi
+
+  if [[ -n "$(git -C "$path" status --short)" ]]; then
+    printf 'skip dirty worktree: %s\n' "$path" >&2
+    continue
+  fi
+
+  if [[ "$dry_run" == true ]]; then
+    printf 'would remove: %s\n' "$path"
+  else
+    git worktree remove "$path"
+    printf 'removed: %s\n' "$path"
+  fi
+done < <(find "$worktrees_dir" -mindepth 1 -maxdepth 1 -type d -print0)
+
+git worktree prune

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/create-worktree.sh <branch-name> [base-branch] [worktrees-dir]
+
+Examples:
+  scripts/create-worktree.sh PT-65
+  scripts/create-worktree.sh PT-65 main ../worktrees
+
+Creates a git worktree for a feature branch without switching the current checkout.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+branch="${1:-}"
+base_branch="${2:-main}"
+worktrees_dir="${3:-../worktrees}"
+
+if [[ -z "$branch" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "error: run this script inside a git repository" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+target_dir="$worktrees_dir/$branch"
+mkdir -p "$worktrees_dir"
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  git worktree add "$target_dir" "$branch"
+else
+  git worktree add -b "$branch" "$target_dir" "$base_branch"
+fi
+
+printf 'created worktree: %s\n' "$target_dir"

--- a/scripts/validate-template.ps1
+++ b/scripts/validate-template.ps1
@@ -1,0 +1,107 @@
+$ErrorActionPreference = "Stop"
+
+$requiredPaths = @(
+  "AGENTS.md",
+  "README.md",
+  "config.example.toml",
+  "agents/architect.toml",
+  "agents/explorer.toml",
+  "agents/frontend.toml",
+  "agents/qa.toml",
+  "agents/reviewer.toml",
+  "agents/writer.toml",
+  "prompts/issue-analysis.md",
+  "prompts/implement.md",
+  "prompts/review.md",
+  "prompts/pr-description.md",
+  "scripts/create-worktree.sh",
+  "scripts/cleanup-worktrees.sh"
+)
+
+$missing = @()
+
+foreach ($path in $requiredPaths) {
+  if (-not (Test-Path -LiteralPath $path)) {
+    $missing += $path
+  }
+}
+
+if ($missing.Count -gt 0) {
+  foreach ($path in $missing) {
+    Write-Error "missing: $path"
+  }
+
+  exit 1
+}
+
+$agentFiles = Get-ChildItem -LiteralPath "agents" -Filter "*.toml"
+
+foreach ($file in $agentFiles) {
+  $content = Get-Content -Raw -LiteralPath $file.FullName
+
+  if ($content -match 'model\s*=\s*"gpt-') {
+    Write-Error "agent uses a concrete model instead of a placeholder: $($file.Name)"
+    exit 1
+  }
+
+  if ($content -notmatch 'model\s*=\s*"<(MAIN|FAST|REVIEW)_MODEL>"') {
+    Write-Error "agent is missing an approved model placeholder: $($file.Name)"
+    exit 1
+  }
+
+  if ($content -match '(?m)^reasoning_effort\s*=') {
+    Write-Error "agent uses legacy reasoning_effort instead of model_reasoning_effort: $($file.Name)"
+    exit 1
+  }
+
+  if ($content -notmatch 'model_reasoning_effort\s*=\s*"(minimal|low|medium|high|xhigh)"') {
+    Write-Error "agent is missing model_reasoning_effort: $($file.Name)"
+    exit 1
+  }
+
+  if ($content -notmatch 'developer_instructions\s*=\s*"""') {
+    Write-Error "agent is missing developer_instructions: $($file.Name)"
+    exit 1
+  }
+}
+
+$config = Get-Content -Raw -LiteralPath "config.example.toml"
+
+if ($config -match '\[features\]') {
+  Write-Error "config.example.toml should not use the legacy [features] multi_agent block"
+  exit 1
+}
+
+if ($config -match '(?m)^max_threads\s*=|^max_depth\s*=') {
+  Write-Error "config.example.toml should not use legacy max_threads or max_depth keys"
+  exit 1
+}
+
+if ($config -notmatch 'enabled\s*=\s*true') {
+  Write-Error "config.example.toml must enable agents"
+  exit 1
+}
+
+if ($config -notmatch 'max_concurrent_threads_per_session\s*=\s*4') {
+  Write-Error "config.example.toml must set max_concurrent_threads_per_session"
+  exit 1
+}
+
+if ($config -notmatch 'default_subagent_model\s*=\s*"<FAST_MODEL>"') {
+  Write-Error "config.example.toml must use <FAST_MODEL> as the default subagent placeholder"
+  exit 1
+}
+
+foreach ($name in @("architect", "explorer", "frontend", "qa", "reviewer", "writer")) {
+  if ($config -notmatch "\[agents\.$name\]") {
+    Write-Error "config.example.toml is missing [agents.$name]"
+    exit 1
+  }
+
+  if ($config -notmatch "config_file\s*=\s*""agents/$name\.toml""") {
+    Write-Error "config.example.toml is missing config_file for $name"
+    exit 1
+  }
+}
+
+Write-Host "Template structure OK"

--- a/scripts/validate-template.ps1
+++ b/scripts/validate-template.ps1
@@ -98,6 +98,11 @@ foreach ($name in @("architect", "explorer", "frontend", "qa", "reviewer", "writ
     exit 1
   }
 
+  if ($config -notmatch "(?s)\[agents\.$name\].*?description\s*=\s*""[^""]+""") {
+    Write-Error "config.example.toml is missing description for $name"
+    exit 1
+  }
+
   if ($config -notmatch "config_file\s*=\s*""agents/$name\.toml""") {
     Write-Error "config.example.toml is missing config_file for $name"
     exit 1

--- a/scripts/validate-template.sh
+++ b/scripts/validate-template.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_paths=(
+  "AGENTS.md"
+  "README.md"
+  "config.example.toml"
+  "agents/architect.toml"
+  "agents/explorer.toml"
+  "agents/frontend.toml"
+  "agents/qa.toml"
+  "agents/reviewer.toml"
+  "agents/writer.toml"
+  "prompts/issue-analysis.md"
+  "prompts/implement.md"
+  "prompts/review.md"
+  "prompts/pr-description.md"
+  "scripts/create-worktree.sh"
+  "scripts/cleanup-worktrees.sh"
+)
+
+missing=0
+
+for path in "${required_paths[@]}"; do
+  if [[ ! -e "$path" ]]; then
+    printf 'missing: %s\n' "$path" >&2
+    missing=1
+  fi
+done
+
+for script in scripts/*.sh; do
+  bash -n "$script"
+done
+
+if grep -R -nE 'model = "gpt-|^reasoning_effort = ' agents config.example.toml; then
+  printf 'legacy or concrete model configuration found\n' >&2
+  missing=1
+fi
+
+if grep -nE '^\[features\]|^max_threads = |^max_depth = ' config.example.toml; then
+  printf 'legacy agent configuration found in config.example.toml\n' >&2
+  missing=1
+fi
+
+for name in architect explorer frontend qa reviewer writer; do
+  if ! grep -q "\\[agents\\.$name\\]" config.example.toml; then
+    printf 'missing config section: [agents.%s]\n' "$name" >&2
+    missing=1
+  fi
+
+  if ! grep -q "config_file = \"agents/$name.toml\"" config.example.toml; then
+    printf 'missing config_file for agent: %s\n' "$name" >&2
+    missing=1
+  fi
+
+  if ! grep -qE 'model_reasoning_effort = "(minimal|low|medium|high|xhigh)"' "agents/$name.toml"; then
+    printf 'missing model_reasoning_effort for agent: %s\n' "$name" >&2
+    missing=1
+  fi
+done
+
+if [[ "$missing" -eq 0 ]]; then
+  printf 'Template structure OK\n'
+fi
+
+exit "$missing"

--- a/scripts/validate-template.sh
+++ b/scripts/validate-template.sh
@@ -48,6 +48,11 @@ for name in architect explorer frontend qa reviewer writer; do
     missing=1
   fi
 
+  if ! awk "/\\[agents\\.$name\\]/{flag=1; next} /^\\[agents\\./{flag=0} flag && /^description = \".+\"/{found=1} END{exit !found}" config.example.toml; then
+    printf 'missing description for agent: %s\n' "$name" >&2
+    missing=1
+  fi
+
   if ! grep -q "config_file = \"agents/$name.toml\"" config.example.toml; then
     printf 'missing config_file for agent: %s\n' "$name" >&2
     missing=1


### PR DESCRIPTION
## Summary

Adds a reusable Codex team template for the portfolio repository, including shared agent guidance, reusable prompts, placeholder agent config examples, and worktree helper scripts.

## Changes

- Replaces `AGENTS.md` with role-based team workflow guidance.
- Adds reusable prompts for issue analysis, implementation, review, and PR descriptions.
- Adds worktree creation and cleanup helper scripts.
- Adds `config.example.toml` and placeholder `agents/*.toml` files using `<MAIN_MODEL>`, `<FAST_MODEL>`, and `<REVIEW_MODEL>` instead of concrete local model IDs.
- Adds template validation scripts for PowerShell and Bash.

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts\validate-template.ps1` passed.
- Checked staged files for real Codex config/model references; only the validator rule that detects `gpt-` matched.
- `bash scripts/validate-template.sh` could not run in this sandbox because Bash startup failed with `E_ACCESSDENIED`.

## Notes

No personal `~/.codex/config.toml` or repo-local `.codex/config.toml` was committed.