### PR TITLE
feat(PT-41): enhance experience page with current and previous roles, add context and responsibilities sections

### DIFF
--- a/src/content/experience/example-frontend-role.md
+++ b/src/content/experience/example-frontend-role.md
@@ -11,11 +11,16 @@ capabilities:
 
 > Representative validation content only. This is not a claim about a real employer, role, date, or professional outcome.
 
-## Context
+### Context
 
 This entry demonstrates where public-safe context for a professional role can be authored.
 
-## Responsibilities
+### Responsibilities
 
 - Describe representative responsibilities without naming a real organisation or customer.
 - Keep structured periods in frontmatter and presentation wording out of the stored contract.
+
+### Selected contributions
+
+- Keep the public role narrative in canonical Markdown so reviewed context can
+  grow without changing the page template.

--- a/src/content/experience/example-previous-role.md
+++ b/src/content/experience/example-previous-role.md
@@ -1,0 +1,22 @@
+---
+organisation: Representative delivery team
+role: Example previous role
+summary: A concise non-definitive entry used to validate completed-role presentation.
+startPeriod: 2024-05
+endPeriod: 2025-12
+capabilities:
+  - Delivery support
+  - Collaborative delivery
+---
+
+> Representative validation content only. This is not a claim about a real employer, role, date, or professional outcome.
+
+### Context
+
+This completed entry demonstrates the concise, public-safe depth available for
+a previous role.
+
+### Responsibilities
+
+- Delivery support for representative work, without naming internal products,
+  customers, or outcomes.

--- a/src/lib/content/experience.ts
+++ b/src/lib/content/experience.ts
@@ -1,6 +1,6 @@
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { getCollection, render, type CollectionEntry } from 'astro:content';
 
-import type { ExperiencePreview } from './models';
+import type { ExperienceDocument, ExperiencePreview } from './models';
 
 type ExperienceEntry = CollectionEntry<'experience'>;
 
@@ -47,4 +47,22 @@ export async function getExperienceById(
   const entry = entries.find((candidate) => candidate.id === id);
 
   return entry === undefined ? undefined : toExperiencePreview(entry);
+}
+
+export async function getExperienceDocuments(): Promise<ExperienceDocument[]> {
+  const entries = await getCollection('experience');
+  const documents = await Promise.all(
+    entries.map(async (entry) => {
+      const { Content } = await render(entry);
+
+      return {
+        data: toExperiencePreview(entry),
+        Content,
+      };
+    }),
+  );
+
+  return documents.sort((left, right) =>
+    compareExperience(left.data, right.data),
+  );
 }

--- a/src/lib/content/models.ts
+++ b/src/lib/content/models.ts
@@ -40,3 +40,8 @@ export interface ExperiencePreview {
   isCurrent: boolean;
   capabilities: string[];
 }
+
+export interface ExperienceDocument {
+  data: ExperiencePreview;
+  Content: RenderResult['Content'];
+}

--- a/src/pages/experience/index.astro
+++ b/src/pages/experience/index.astro
@@ -1,5 +1,21 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import TagList from '../../components/TagList.astro';
+import { getExperienceDocuments } from '../../lib/content/experience';
+
+const experience = await getExperienceDocuments();
+const currentRoles = experience.filter(({ data }) => data.isCurrent);
+const previousRoles = experience.filter(({ data }) => !data.isCurrent);
+
+const monthFormatter = new Intl.DateTimeFormat('en', {
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+function formatPeriod(period: string): string {
+  return monthFormatter.format(new Date(`${period}-01T00:00:00Z`));
+}
 ---
 
 <BaseLayout
@@ -7,5 +23,418 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   description="Professional experience, engineering judgement, and delivery capabilities from Luis Arostegui Ruiz."
   pathname="/experience/"
 >
-  <h1>Experience</h1>
+  <section class="experience-hero" aria-labelledby="experience-heading">
+    <p class="eyebrow">Professional trajectory</p>
+    <h1 id="experience-heading">Experience</h1>
+    <p>
+      Frontend-focused engineering experience, presented through public-safe
+      context, responsibilities, and evidence-oriented contributions rather than
+      a decorative chronology.
+    </p>
+  </section>
+
+  <section class="professional-context" aria-labelledby="context-heading">
+    <div class="section-header">
+      <p class="eyebrow">Positioning</p>
+      <h2 id="context-heading">Professional context</h2>
+    </div>
+    <p>
+      My primary focus is frontend engineering with React and TypeScript,
+      supported by accessibility, testing, maintainable architecture, and
+      collaboration across the wider software-delivery context.
+    </p>
+  </section>
+
+  {
+    currentRoles.length > 0 && (
+      <section
+        class="experience-section"
+        aria-labelledby="current-roles-heading"
+      >
+        <div class="section-header">
+          <p class="eyebrow">Active work</p>
+          <h2 id="current-roles-heading">Current role</h2>
+        </div>
+        <ol class="role-list" aria-label="Current professional roles">
+          {currentRoles.map((role) => (
+            <li>
+              <article
+                class="role-entry"
+                aria-labelledby={`${role.data.id}-heading`}
+              >
+                <div class="role-entry__heading">
+                  <p class="metadata">Current role</p>
+                  <h3 id={`${role.data.id}-heading`}>{role.data.role}</h3>
+                  <p class="role-entry__organisation">
+                    {role.data.organisation}
+                  </p>
+                  <p class="role-entry__period">
+                    <time datetime={`${role.data.startPeriod}-01`}>
+                      {formatPeriod(role.data.startPeriod)}
+                    </time>{' '}
+                    - Present
+                  </p>
+                </div>
+                <div class="role-entry__content">
+                  <p class="role-entry__summary">{role.data.summary}</p>
+                  <div class="prose">
+                    <role.Content />
+                  </div>
+                  <div class="capabilities">
+                    <h4>Capabilities demonstrated</h4>
+                    <TagList
+                      items={role.data.capabilities}
+                      ariaLabel={`${role.data.role} capabilities`}
+                    />
+                  </div>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ol>
+      </section>
+    )
+  }
+
+  {
+    previousRoles.length > 0 && (
+      <section
+        class="experience-section"
+        aria-labelledby="previous-roles-heading"
+      >
+        <div class="section-header">
+          <p class="eyebrow">Professional history</p>
+          <h2 id="previous-roles-heading">Previous roles</h2>
+        </div>
+        <ol class="role-list" aria-label="Previous professional roles">
+          {previousRoles.map((role) => (
+            <li>
+              <article
+                class="role-entry"
+                aria-labelledby={`${role.data.id}-heading`}
+              >
+                <div class="role-entry__heading">
+                  <p class="metadata">Previous role</p>
+                  <h3 id={`${role.data.id}-heading`}>{role.data.role}</h3>
+                  <p class="role-entry__organisation">
+                    {role.data.organisation}
+                  </p>
+                  <p class="role-entry__period">
+                    <time datetime={`${role.data.startPeriod}-01`}>
+                      {formatPeriod(role.data.startPeriod)}
+                    </time>{' '}
+                    -{' '}
+                    {role.data.endPeriod !== null && (
+                      <time datetime={`${role.data.endPeriod}-01`}>
+                        {formatPeriod(role.data.endPeriod)}
+                      </time>
+                    )}
+                  </p>
+                </div>
+                <div class="role-entry__content">
+                  <p class="role-entry__summary">{role.data.summary}</p>
+                  <div class="prose">
+                    <role.Content />
+                  </div>
+                  <div class="capabilities">
+                    <h4>Capabilities demonstrated</h4>
+                    <TagList
+                      items={role.data.capabilities}
+                      ariaLabel={`${role.data.role} capabilities`}
+                    />
+                  </div>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ol>
+      </section>
+    )
+  }
+
+  <section class="contribution-focus" aria-labelledby="contribution-heading">
+    <div class="section-header">
+      <p class="eyebrow">How to read this page</p>
+      <h2 id="contribution-heading">Contribution focus</h2>
+    </div>
+    <p>
+      Each entry separates ongoing responsibilities from selected contributions.
+      That keeps the useful engineering context visible while allowing the
+      amount of canonical Markdown to match the public evidence available.
+    </p>
+  </section>
+
+  <section class="continuation" aria-labelledby="continuation-heading">
+    <div>
+      <p class="eyebrow">Next steps</p>
+      <h2 id="continuation-heading">Continue exploring</h2>
+      <p>
+        Review project evidence, inspect the public engineering record, or get
+        in touch for a professional conversation.
+      </p>
+    </div>
+    <div class="action-group" aria-label="Experience continuation paths">
+      <a class="action action--primary" href="/projects/">View projects</a>
+      <a class="action action--secondary" href="/#contact">Contact</a>
+      <a
+        class="action action--secondary"
+        href="https://github.com/LuisArostegui"
+        rel="noreferrer"
+        target="_blank"
+      >
+        GitHub profile
+      </a>
+    </div>
+  </section>
 </BaseLayout>
+
+<style>
+  :global(#main-content) {
+    inline-size: min(
+      100% - (2 * var(--layout-gutter-mobile)),
+      var(--layout-content-wide)
+    );
+  }
+
+  .experience-hero,
+  .professional-context,
+  .experience-section,
+  .contribution-focus,
+  .continuation,
+  .role-entry {
+    overflow-wrap: anywhere;
+  }
+
+  .experience-hero {
+    max-inline-size: var(--layout-content-readable);
+    padding-block-end: var(--space-7);
+    border-block-end: 1px solid var(--colour-border-subtle);
+  }
+
+  .experience-hero h1 {
+    margin-block: var(--space-3) var(--space-4);
+    font-size: var(--type-heading-1-font-size);
+    line-height: var(--type-heading-1-line-height);
+  }
+
+  .experience-hero p:not(.eyebrow),
+  .professional-context > p,
+  .contribution-focus > p,
+  .continuation p:not(.eyebrow),
+  .role-entry__summary {
+    margin-block: 0;
+    color: var(--colour-text-secondary);
+  }
+
+  .experience-hero p:not(.eyebrow),
+  .professional-context > p {
+    font-size: var(--type-body-large-font-size);
+    line-height: var(--type-body-large-line-height);
+  }
+
+  .professional-context,
+  .experience-section,
+  .contribution-focus,
+  .continuation {
+    padding-block: var(--space-7);
+    border-block-end: 1px solid var(--colour-border-subtle);
+  }
+
+  .professional-context > p,
+  .contribution-focus > p {
+    max-inline-size: var(--layout-content-readable);
+  }
+
+  .section-header {
+    max-inline-size: var(--layout-content-readable);
+    margin-block-end: var(--space-5);
+  }
+
+  .section-header h2,
+  .continuation h2 {
+    margin-block: var(--space-2) 0;
+  }
+
+  .eyebrow,
+  .metadata,
+  .role-entry__period {
+    margin-block: 0;
+    color: var(--colour-text-muted);
+    font-family: var(--type-metadata-font-family);
+    font-size: var(--type-metadata-font-size);
+    font-weight: var(--type-metadata-font-weight);
+    line-height: var(--type-metadata-line-height);
+    text-transform: uppercase;
+  }
+
+  .role-list {
+    display: grid;
+    gap: var(--space-4);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .role-entry {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-5);
+    border: 1px solid var(--colour-border-subtle);
+    border-radius: var(--radius-1);
+    background-color: var(--colour-surface-default);
+  }
+
+  .role-entry h3 {
+    margin-block: var(--space-2) var(--space-1);
+    font-size: var(--type-heading-3-font-size);
+    line-height: var(--type-heading-3-line-height);
+  }
+
+  .role-entry__organisation {
+    margin-block: 0 var(--space-2);
+    color: var(--colour-text-secondary);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+    line-height: var(--type-label-line-height);
+  }
+
+  .role-entry__content {
+    display: grid;
+    gap: var(--space-4);
+    min-inline-size: 0;
+  }
+
+  .prose {
+    max-inline-size: var(--layout-content-readable);
+    color: var(--colour-text-secondary);
+  }
+
+  .prose :global(p),
+  .prose :global(ul),
+  .prose :global(blockquote) {
+    margin-block: 0;
+  }
+
+  .prose :global(* + *) {
+    margin-block-start: var(--space-3);
+  }
+
+  .prose :global(h3) {
+    color: var(--colour-text-primary);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+    line-height: var(--type-label-line-height);
+  }
+
+  .prose :global(ul) {
+    padding-inline-start: var(--space-5);
+  }
+
+  .prose :global(li + li) {
+    margin-block-start: var(--space-2);
+  }
+
+  .prose :global(blockquote) {
+    padding-inline-start: var(--space-3);
+    border-inline-start: 2px solid var(--colour-border-accent);
+    color: var(--colour-text-muted);
+  }
+
+  .capabilities h4 {
+    margin-block: 0 var(--space-2);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+    line-height: var(--type-label-line-height);
+  }
+
+  .continuation {
+    display: grid;
+    gap: var(--space-5);
+    border-block-end: 0;
+  }
+
+  .continuation > div:first-child {
+    max-inline-size: var(--layout-content-readable);
+  }
+
+  .action-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    align-content: start;
+  }
+
+  .action {
+    display: inline-flex;
+    min-block-size: 44px;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--colour-border-strong);
+    border-radius: var(--radius-1);
+    font-family: var(--type-label-font-family);
+    font-size: var(--type-label-font-size);
+    font-weight: var(--type-label-font-weight);
+    text-align: center;
+    text-decoration: none;
+  }
+
+  .action--primary {
+    border-color: var(--colour-accent-default);
+    background-color: var(--colour-accent-default);
+    color: var(--colour-text-on-accent);
+  }
+
+  .action--primary:hover,
+  .action--primary:active {
+    background-color: var(--colour-accent-hover);
+    color: var(--colour-text-on-accent);
+  }
+
+  .action--secondary {
+    color: var(--colour-text-primary);
+  }
+
+  .action--secondary:hover {
+    border-color: var(--colour-border-accent);
+    color: var(--colour-text-primary);
+  }
+
+  @media (min-width: 48rem) {
+    :global(#main-content) {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-tablet)),
+        var(--layout-content-wide)
+      );
+    }
+
+    .role-entry {
+      grid-template-columns: minmax(12rem, 0.55fr) minmax(0, 1fr);
+    }
+
+    .continuation {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: end;
+    }
+  }
+
+  @media (min-width: 70rem) {
+    :global(#main-content) {
+      inline-size: min(
+        100% - (2 * var(--layout-gutter-desktop)),
+        var(--layout-content-wide)
+      );
+    }
+
+    .experience-hero,
+    .professional-context,
+    .experience-section,
+    .contribution-focus,
+    .continuation {
+      padding-block: var(--space-8);
+    }
+  }
+</style>

--- a/tests/e2e/experience.spec.ts
+++ b/tests/e2e/experience.spec.ts
@@ -1,0 +1,100 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test('experience renders canonical current and previous role content', async ({
+  page,
+}) => {
+  await page.goto('/experience/');
+
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+    'Experience',
+  );
+  await expect(
+    page.getByRole('heading', { name: 'Professional context', level: 2 }),
+  ).toBeVisible();
+
+  const currentRole = page.getByRole('article').filter({
+    has: page.getByRole('heading', { name: 'Example frontend role' }),
+  });
+  await expect(currentRole).toContainText('Current role');
+  await expect(currentRole).toContainText('Representative product team');
+  await expect(currentRole).toContainText('January 2026 - Present');
+  await expect(currentRole).toContainText(
+    'This entry demonstrates where public-safe context for a professional role can be authored.',
+  );
+  await expect(
+    currentRole.getByRole('heading', { name: 'Responsibilities', level: 3 }),
+  ).toBeVisible();
+  await expect(currentRole).toContainText('Frontend engineering');
+
+  const previousRole = page.getByRole('article').filter({
+    has: page.getByRole('heading', { name: 'Example previous role' }),
+  });
+  await expect(previousRole).toContainText('Previous role');
+  await expect(previousRole).toContainText('Representative delivery team');
+  await expect(previousRole).toContainText('May 2024 - December 2025');
+  await expect(previousRole).toContainText(
+    'A concise non-definitive entry used to validate completed-role presentation.',
+  );
+  await expect(previousRole).toContainText('Delivery support');
+});
+
+test('experience prioritises contribution-led content and continuation paths', async ({
+  page,
+}) => {
+  await page.goto('/experience/');
+
+  await expect(
+    page.getByRole('heading', { name: 'Current role', level: 2 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Previous roles', level: 2 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Contribution focus', level: 2 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Continue exploring', level: 2 }),
+  ).toBeVisible();
+  const continuation = page.getByRole('region', {
+    name: 'Continue exploring',
+  });
+  await expect(
+    continuation.getByRole('link', { name: 'View projects' }),
+  ).toHaveAttribute('href', '/projects/');
+  await expect(
+    continuation.getByRole('link', { name: 'Contact' }),
+  ).toHaveAttribute('href', '/#contact');
+  await expect(
+    continuation.getByRole('link', { name: 'GitHub profile' }),
+  ).toHaveAttribute('href', 'https://github.com/LuisArostegui');
+});
+
+test('experience does not introduce page-level horizontal scrolling on mobile', async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'mobile-chromium',
+    'Mobile-only responsive check',
+  );
+
+  await page.goto('/experience/');
+
+  const hasPageLevelHorizontalScroll = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth >
+      document.documentElement.clientWidth,
+  );
+
+  expect(hasPageLevelHorizontalScroll).toBe(false);
+});
+
+test('experience has no automatically detectable accessibility violations', async ({
+  page,
+}) => {
+  await page.goto('/experience/');
+
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+  expect(accessibilityScanResults.violations).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Implement the initial Experience page for the portfolio using the canonical content system.

The page presents current and previous professional roles through structured Markdown content, emphasising professional context, responsibilities, selected contributions, and demonstrated capabilities while keeping the implementation public-safe and content-driven.

## Related issue

Closes #66

## Changes

- Add the Experience page implementation following the approved design.
- Render canonical Markdown content for each experience entry.
- Distinguish current and previous professional roles.
- Introduce a reusable `ExperienceDocument` model and `getExperienceDocuments()` content query.
- Display context, responsibilities, contributions and capabilities for each role.
- Add continuation links to Projects, Contact and GitHub.
- Add responsive layout and page-specific styling.
- Add Playwright end-to-end tests covering rendering, accessibility and responsive behaviour.

## Repository structure

```text
src/
├── content/
│   └── experience/
│       └── example-previous-role.md
├── lib/
│   └── content/
│       ├── experience.ts
│       └── models.ts
└── pages/
    └── experience/
        └── index.astro

tests/
└── e2e/
    └── experience.spec.ts